### PR TITLE
ci: add scheduled marketplace listing-check workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,11 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     name: test (Python ${{ matrix.python-version }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,14 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     name: pre-commit (ruff, markdownlint, yamllint, cspell, mypy)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "20"
 
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd

--- a/.github/workflows/listings.yml
+++ b/.github/workflows/listings.yml
@@ -1,0 +1,60 @@
+name: Listings
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Mondays 09:00 UTC
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/check_listings_api.py"
+      - ".github/workflows/listings.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: marketplace listing check (HTTP)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Probe marketplaces (HTTP-only, no browser)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p dist
+          # `|| true`: third-party sites time out intermittently; the report
+          # is the signal, not the exit code. Strict topic checks live below.
+          python scripts/check_listings_api.py \
+            --report dist/listings-api.md --json > dist/listings-api.json || true
+          {
+            echo "## Marketplace listing status (HTTP probe)"
+            echo
+            cat dist/listings-api.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if the repo is missing discovery topics
+        run: |
+          python - <<'PY'
+          import json, sys
+          data = json.load(open("dist/listings-api.json"))
+          missing = [r for r in data if r.get("status") == "missing_topic"]
+          for r in missing:
+              print(f"::error::{r.get('detail')}")
+          sys.exit(1 if missing else 0)
+          PY
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: listings-report
+          path: |
+            dist/listings-api.md
+            dist/listings-api.json

--- a/.github/workflows/listings.yml
+++ b/.github/workflows/listings.yml
@@ -28,6 +28,7 @@ jobs:
           python-version: "3.12"
 
       - name: Probe marketplaces (HTTP-only, no browser)
+        timeout-minutes: 10
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -52,6 +53,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: listings-report
+          if-no-files-found: warn
           path: |
             dist/listings-api.md
             dist/listings-api.json

--- a/.github/workflows/listings.yml
+++ b/.github/workflows/listings.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
     paths:
       - "scripts/check_listings_api.py"
+      - "scripts/listing_catalog.py"
       - ".github/workflows/listings.yml"
 
 permissions:
@@ -18,9 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     name: marketplace listing check (HTTP)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
 
@@ -29,30 +32,24 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           mkdir -p dist
-          # `|| true`: third-party sites time out intermittently; the report
-          # is the signal, not the exit code. Strict topic checks live below.
+          set +e
           python scripts/check_listings_api.py \
-            --report dist/listings-api.md --json > dist/listings-api.json || true
+            --strict --report dist/listings-api.md --json > dist/listings-api.json
+          status=$?
           {
             echo "## Marketplace listing status (HTTP probe)"
             echo
-            cat dist/listings-api.md
+            if [[ -f dist/listings-api.md ]]; then
+              cat dist/listings-api.md
+            else
+              echo "Probe did not produce a report."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Fail if the repo is missing discovery topics
-        run: |
-          python - <<'PY'
-          import json, sys
-          data = json.load(open("dist/listings-api.json"))
-          missing = [r for r in data if r.get("status") == "missing_topic"]
-          for r in missing:
-              print(f"::error::{r.get('detail')}")
-          sys.exit(1 if missing else 0)
-          PY
+          exit "$status"
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: listings-report
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,14 @@ jobs:
         run: python scripts/build_artifacts.py "${{ github.ref_name }}"
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
-        with:
-          files: dist/*
-          generate_release_notes: true
-          fail_on_unmatched_files: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          shopt -s nullglob
+          artifacts=(dist/*)
+          if (( ${#artifacts[@]} == 0 )); then
+            echo "::error::No release artifacts found in dist/"
+            exit 1
+          fi
+          gh release create "${GITHUB_REF_NAME}" "${artifacts[@]}" \
+            --generate-notes --title "${GITHUB_REF_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
 
@@ -27,7 +28,7 @@ jobs:
         run: python scripts/build_artifacts.py "${{ github.ref_name }}"
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           files: dist/*
           generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `scripts/check_listings.py` Playwright probe) and a scheduled `listings.yml` workflow
   that runs the HTTP probe weekly, publishes a status report, and fails if the repo loses
   a discovery topic.
+- Workflow hardening for CI, lint, release, and listing checks: GitHub Actions are pinned
+  to full commit SHAs, checkout credentials are not persisted when unused, non-release
+  workflows declare read-only token permissions, and release publishing uses the GitHub CLI
+  instead of a third-party action in the write-token job.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Marketplace listing-check scripts (`scripts/check_listings_api.py` HTTP probe and
+  `scripts/check_listings.py` Playwright probe) and a scheduled `listings.yml` workflow
+  that runs the HTTP probe weekly, publishes a status report, and fails if the repo loses
+  a discovery topic.
+
 ### Changed
 
 - Moved the skill from `b2-cloud-storage/` to `skills/b2-cloud-storage/` so marketplace

--- a/scripts/check_listings.py
+++ b/scripts/check_listings.py
@@ -359,6 +359,7 @@ def run_probe(page: Page, probe: Probe, save_screenshots: bool) -> Result:
         response = page.goto(probe.url, wait_until="domcontentloaded", timeout=timeout)
         if response is None:
             result.error = "no response"
+            return result
         elif response.status >= 400:
             result.status = "blocked" if response.status in (401, 403, 429) else "error"
             result.error = f"HTTP {response.status}"

--- a/scripts/check_listings.py
+++ b/scripts/check_listings.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Probe each skill directory and report whether our skill is listed.
+
+Local setup (one-time):
+
+    pip install playwright
+    playwright install chromium
+
+Usage:
+
+    python scripts/check_listings.py                  # headless, all probes
+    python scripts/check_listings.py --headed         # show the browser
+    python scripts/check_listings.py --only LobeHub   # one directory
+    python scripts/check_listings.py --json           # machine-readable
+    python scripts/check_listings.py --screenshots    # save evidence to dist/listing-checks/
+
+The intent is exploratory: navigate to each directory's search/listing URL,
+look for our skill in the rendered page text, and report. Selectors are
+deliberately loose because every site is laid out differently and many are
+SPAs — we trust the visible text after `networkidle`. Iterate by tightening
+probes for sites that surface false positives or false negatives.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+try:
+    from playwright.sync_api import Page, sync_playwright
+    from playwright.sync_api import TimeoutError as PlaywrightTimeout
+except ImportError:  # pragma: no cover
+    sys.exit(
+        "playwright is not installed. Run:\n"
+        "    pip install playwright && playwright install chromium"
+    )
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCREENSHOT_DIR = REPO_ROOT / "dist" / "listing-checks"
+
+REPO_SLUG = "backblaze-labs/claude-skill-b2-cloud-storage"
+SKILL_NAME = "b2-cloud-storage"
+
+# Phrases we accept as proof of listing. Any one match flips status to "live".
+# Bare "backblaze" was too broad — query echoes ("matching 'backblaze'") tripped it.
+MATCH_TERMS = (
+    "backblaze-labs/claude-skill-b2-cloud-storage",
+    "claude-skill-b2-cloud-storage",
+    "b2-cloud-storage",
+)
+
+Status = Literal["live", "not_found", "error", "blocked"]
+
+# Selectors tried in order when a probe needs interactive search. The first
+# locator that becomes visible wins. Add per-probe overrides via Probe.search_locators.
+DEFAULT_SEARCH_LOCATORS: tuple[str, ...] = (
+    "input[type='search']",
+    "[role='searchbox']",
+    "input[placeholder*='Search' i]",
+    "input[name='q']",
+    "input[name='query']",
+    "input[aria-label*='Search' i]",
+)
+
+
+@dataclass
+class Probe:
+    name: str
+    url: str
+    # Optional CSS/text selector to wait for before sampling page content.
+    # Leave None to use `networkidle`.
+    wait_for: str | None = None
+    # Force-fail on these terms appearing (e.g. captcha, "no results found").
+    negative_terms: tuple[str, ...] = ()
+    # Per-probe override of the default match terms.
+    match_terms: tuple[str, ...] = MATCH_TERMS
+    # Some directories block headless / unknown UAs. Set True to use a longer timeout.
+    slow: bool = False
+    # If set, navigate to `url` (no query string), then type this term into a
+    # search input and press Enter. Use for SPAs that ignore `?q=` URL params.
+    search_query: str | None = None
+    # Override search input selectors when the defaults miss.
+    search_locators: tuple[str, ...] = DEFAULT_SEARCH_LOCATORS
+
+
+@dataclass
+class Result:
+    name: str
+    url: str
+    status: Status
+    matched_term: str | None = None
+    error: str | None = None
+    snippet: str | None = None
+    screenshot: str | None = None
+    duration_ms: int = 0
+    extras: dict[str, str] = field(default_factory=dict)
+
+
+PROBES: tuple[Probe, ...] = (
+    # URL-query directories (their `?q=` filters server-side or via SPA router)
+    Probe(
+        "SkillsMP",
+        "https://skillsmp.com/?q=backblaze",
+        negative_terms=("No skills found",),
+    ),
+    Probe(
+        "SkillsLLM",
+        "https://skillsllm.com/?q=backblaze",
+        negative_terms=("No results", "Nothing found"),
+    ),
+    Probe(
+        "LobeHub Skills",
+        "https://lobehub.com/skills?q=backblaze",
+        negative_terms=("No skills found",),
+    ),
+    Probe(
+        "Pawgrammer Skills Market",
+        "https://skills.pawgrammer.com/?q=backblaze",
+        negative_terms=("No skills found", "couldn't find any skills"),
+    ),
+    # Interactive-search directories (homepage `?q=` is ignored; type into search box)
+    # Claude Marketplaces homepage has no free-text search input — only category
+    # browsing and email subscribe forms. Best signal we can get without a known
+    # canonical URL is checking if `b2-cloud-storage` appears anywhere on the
+    # rendered listings page.
+    Probe(
+        "Claude Marketplaces",
+        "https://claudemarketplaces.com/",
+        negative_terms=("No marketplaces found", "0 results"),
+    ),
+    # ClaudeSkills.info /skills exposes no input element. Their homepage may
+    # have a header search; try that instead.
+    Probe(
+        "ClaudeSkills.info",
+        "https://claudeskills.info/",
+        search_query="backblaze",
+        slow=True,
+        negative_terms=("No skills found",),
+    ),
+    Probe(
+        "Agent Skills Market",
+        "https://www.agentskillsmarket.space/",
+        search_query="backblaze",
+        negative_terms=("No skills found", "0 results"),
+    ),
+    Probe(
+        "SkillHub",
+        "https://skillhub.club/",
+        search_query="backblaze",
+        # Their search input is `type='text'` with placeholder "Search Skills..." —
+        # the generic locators miss the no-`type=search` case, so list it explicitly.
+        search_locators=(
+            "input[placeholder='Search Skills...' i]",
+            "input[placeholder*='Search Skills' i]",
+            *DEFAULT_SEARCH_LOCATORS,
+        ),
+        negative_terms=("No results", "No skills"),
+    ),
+    # Direct text probe — no UI involved
+    Probe(
+        "Awesome Claude Skills",
+        "https://raw.githubusercontent.com/travisvn/awesome-claude-skills/main/README.md",
+        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+    ),
+    Probe(
+        "Awesome Claude Plugins",
+        "https://raw.githubusercontent.com/Chat2AnyLLM/awesome-claude-plugins/main/README.md",
+        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+    ),
+    Probe(
+        "Awesome Agent Skills",
+        "https://raw.githubusercontent.com/heilcheng/awesome-agent-skills/main/README.md",
+        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+    ),
+    # Anthropic's official directories
+    Probe(
+        "Anthropic claude-plugins-official",
+        "https://raw.githubusercontent.com/anthropics/claude-plugins-official/main/README.md",
+        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage", "backblaze"),
+    ),
+    Probe(
+        "Anthropic skills",
+        "https://raw.githubusercontent.com/anthropics/skills/main/README.md",
+        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage", "backblaze"),
+    ),
+    Probe(
+        "claude.com Skills",
+        "https://claude.com/skills?q=backblaze",
+        slow=True,
+        negative_terms=("No skills found", "0 results"),
+    ),
+    # WordPress-style search (?s=)
+    Probe(
+        "Cult of Claude",
+        "https://cultofclaude.com/skills/?s=backblaze",
+        negative_terms=("Nothing Found", "Sorry, but nothing matched"),
+    ),
+    # Community marketplaces — also crawl GitHub topics
+    Probe(
+        "alirezarezvani/claude-skills",
+        "https://raw.githubusercontent.com/alirezarezvani/claude-skills/main/README.md",
+        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+    ),
+    Probe(
+        "daymade/claude-code-skills",
+        "https://raw.githubusercontent.com/daymade/claude-code-skills/main/README.md",
+        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+    ),
+    Probe(
+        "mhattingpete/claude-skills-marketplace",
+        "https://raw.githubusercontent.com/mhattingpete/claude-skills-marketplace/main/README.md",
+        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+    ),
+    # Tier-1 aggregators added 2026-05. Raw README grep — no JS needed but kept
+    # here for parity with the rest of the directory list and one-stop reporting.
+    Probe(
+        "VoltAgent/awesome-agent-skills",
+        "https://raw.githubusercontent.com/VoltAgent/awesome-agent-skills/main/README.md",
+        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+    ),
+    Probe(
+        "hesreallyhim/awesome-claude-code",
+        "https://raw.githubusercontent.com/hesreallyhim/awesome-claude-code/main/README.md",
+        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+    ),
+    Probe(
+        "ComposioHQ/awesome-claude-skills",
+        # Default branch is `master`, not `main`.
+        "https://raw.githubusercontent.com/ComposioHQ/awesome-claude-skills/master/README.md",
+        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+    ),
+    Probe(
+        "netresearch/claude-code-marketplace",
+        # The manifest is the authoritative listing; README may lag.
+        "https://raw.githubusercontent.com/netresearch/claude-code-marketplace/main/.claude-plugin/marketplace.json",
+        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage", "b2-cloud-storage"),
+    ),
+    # Tier-2 community lists
+    Probe(
+        "rohitg00/awesome-claude-code-toolkit",
+        "https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolkit/main/README.md",
+        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+    ),
+    Probe(
+        "BehiSecc/awesome-claude-skills",
+        "https://raw.githubusercontent.com/BehiSecc/awesome-claude-skills/main/README.md",
+        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+    ),
+    Probe(
+        "jqueryscript/awesome-claude-code",
+        "https://raw.githubusercontent.com/jqueryscript/awesome-claude-code/main/README.md",
+        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+    ),
+    # SPA aggregators — must use Playwright (mcpmarket 403s plain curl, awesomeclaude
+    # is a Next.js site that hydrates client-side).
+    Probe(
+        "MCP Market — Skills",
+        "https://mcpmarket.com/tools/skills?q=backblaze",
+        slow=True,
+        negative_terms=("No skills found", "No results", "0 results"),
+    ),
+    Probe(
+        "awesomeclaude.ai",
+        "https://awesomeclaude.ai/awesome-claude-skills",
+        search_query="backblaze",
+        slow=True,
+        negative_terms=("No skills found", "No results"),
+    ),
+)
+
+
+def _snippet_around(text: str, term: str, span: int = 80) -> str:
+    """Return ~`span` chars of context around the first occurrence of `term`."""
+    idx = text.lower().find(term.lower())
+    if idx < 0:
+        return ""
+    start = max(0, idx - span)
+    end = min(len(text), idx + len(term) + span)
+    return re.sub(r"\s+", " ", text[start:end]).strip()
+
+
+def _check_page_text(text: str, probe: Probe) -> tuple[Status, str | None, str | None]:
+    """Return (status, matched_term, snippet) for the rendered text."""
+    haystack = text.lower()
+    for neg in probe.negative_terms:
+        if neg.lower() in haystack:
+            return "not_found", None, _snippet_around(text, neg)
+    for term in probe.match_terms:
+        if term.lower() in haystack:
+            return "live", term, _snippet_around(text, term)
+    return "not_found", None, None
+
+
+def _dismiss_overlays(page: Page) -> None:
+    """Best-effort: close common modals/banners that block search input."""
+    # Two Escape presses — some modals require it; one to defocus, one to close.
+    for _ in range(2):
+        try:
+            page.keyboard.press("Escape", timeout=500)
+            page.wait_for_timeout(150)
+        except Exception:
+            pass
+    candidates = (
+        'button[aria-label="Dismiss"]',
+        'button[aria-label="Close"]',
+        '[aria-label*="close" i]',
+        '[aria-label*="dismiss" i]',
+        'button:has-text("Got it")',
+        'button:has-text("Accept")',
+        'button:has-text("Dismiss")',
+        'button:has-text("Close")',
+    )
+    for sel in candidates:
+        try:
+            loc = page.locator(sel).first
+            if loc.is_visible(timeout=400):
+                # force=True bypasses overlay-intercepts; clicking through is what we want.
+                loc.click(timeout=1500, force=True)
+                page.wait_for_timeout(250)
+        except Exception:
+            continue
+
+
+def _interactive_search(page: Page, probe: Probe) -> str | None:
+    """Find a search input, type the query, press Enter. Returns the locator
+    that worked (for debugging) or None if all candidates failed."""
+    if not probe.search_query:
+        return None
+    _dismiss_overlays(page)
+    for sel in probe.search_locators:
+        try:
+            loc = page.locator(sel).first
+            if not loc.is_visible(timeout=1500):
+                continue
+            loc.fill(probe.search_query, timeout=2000)
+            loc.press("Enter", timeout=2000)
+            with contextlib.suppress(PlaywrightTimeout):
+                page.wait_for_load_state("networkidle", timeout=10_000)
+            # Some search UIs debounce — give the DOM another moment.
+            page.wait_for_timeout(800)
+            return sel
+        except Exception:
+            continue
+    return None
+
+
+def run_probe(page: Page, probe: Probe, save_screenshots: bool) -> Result:
+    started = datetime.now(timezone.utc)
+    result = Result(name=probe.name, url=probe.url, status="error")
+    try:
+        timeout = 60_000 if probe.slow else 30_000
+        response = page.goto(probe.url, wait_until="domcontentloaded", timeout=timeout)
+        if response is None:
+            result.error = "no response"
+        elif response.status >= 400:
+            result.status = "blocked" if response.status in (401, 403, 429) else "error"
+            result.error = f"HTTP {response.status}"
+            return result
+
+        # Best-effort: let SPAs settle. Don't fail if networkidle never resolves.
+        with contextlib.suppress(PlaywrightTimeout):
+            page.wait_for_load_state("networkidle", timeout=15_000)
+
+        if probe.wait_for:
+            with contextlib.suppress(PlaywrightTimeout):
+                page.wait_for_selector(probe.wait_for, timeout=10_000)
+
+        # Interactive search if configured (homepage doesn't honor ?q=).
+        if probe.search_query:
+            used = _interactive_search(page, probe)
+            result.extras["search_locator"] = used or "<none-matched>"
+
+        # Pull rendered text. `inner_text("body")` reflects what a user sees,
+        # ignoring HTML attributes / JSON blobs.
+        try:
+            text = page.inner_text("body")
+        except PlaywrightTimeout:
+            text = page.content()  # fall back to raw HTML for raw.githubusercontent.com etc.
+
+        status, matched, snippet = _check_page_text(text, probe)
+        result.status = status
+        result.matched_term = matched
+        result.snippet = snippet
+
+    except PlaywrightTimeout as exc:
+        result.error = f"timeout: {exc}"
+    except Exception as exc:
+        result.error = f"{type(exc).__name__}: {exc}"
+    finally:
+        if save_screenshots and probe.url.startswith("http") and result.status != "error":
+            SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
+            path = SCREENSHOT_DIR / f"{probe.name.replace(' ', '_')}.png"
+            try:
+                page.screenshot(path=str(path), full_page=True)
+                result.screenshot = str(path.relative_to(REPO_ROOT))
+            except Exception:
+                pass
+        result.duration_ms = int((datetime.now(timezone.utc) - started).total_seconds() * 1000)
+    return result
+
+
+def render_markdown(results: list[Result]) -> str:
+    icon = {"live": "✅", "not_found": "❌", "error": "⚠️", "blocked": "🔒"}
+    lines = [
+        f"# Listing status — {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}",
+        f"Repo: `{REPO_SLUG}`  •  Skill: `{SKILL_NAME}`",
+        "",
+        "| Directory | Status | Matched | Detail |",
+        "|---|---|---|---|",
+    ]
+    for r in results:
+        detail = r.error or r.snippet or ""
+        if len(detail) > 90:
+            detail = detail[:87] + "…"
+        lines.append(
+            f"| {r.name} | {icon.get(r.status, '?')} {r.status} "
+            f"| {r.matched_term or '—'} | {detail} |"
+        )
+    live = sum(1 for r in results if r.status == "live")
+    lines += ["", f"**{live}/{len(results)} live.**"]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--headed", action="store_true", help="Show browser window")
+    parser.add_argument("--only", action="append", help="Restrict to one directory (repeatable)")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of markdown")
+    parser.add_argument(
+        "--screenshots",
+        action="store_true",
+        help="Save full-page screenshots to dist/listing-checks/",
+    )
+    parser.add_argument(
+        "--user-agent",
+        default=(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"
+        ),
+    )
+    args = parser.parse_args()
+
+    probes: list[Probe] = list(PROBES)
+    if args.only:
+        wanted = {n.lower() for n in args.only}
+        probes = [p for p in probes if p.name.lower() in wanted]
+        if not probes:
+            print(f"No matching probes for --only {args.only}", file=sys.stderr)
+            return 2
+
+    results: list[Result] = []
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(headless=not args.headed)
+        context = browser.new_context(
+            user_agent=args.user_agent, viewport={"width": 1366, "height": 900}
+        )
+        page = context.new_page()
+        for probe in probes:
+            print(f"  → {probe.name}  …  ", end="", flush=True, file=sys.stderr)
+            r = run_probe(page, probe, save_screenshots=args.screenshots)
+            results.append(r)
+            tag = r.matched_term or r.error or "—"
+            print(f"{r.status}  ({r.duration_ms}ms)  {tag}", file=sys.stderr)
+        context.close()
+        browser.close()
+
+    if args.json:
+        print(json.dumps([asdict(r) for r in results], indent=2))
+    else:
+        print(render_markdown(results))
+    return 0 if all(r.status in ("live", "not_found") for r in results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_listings.py
+++ b/scripts/check_listings.py
@@ -31,63 +31,22 @@ import sys
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 try:
     from playwright.sync_api import Page, sync_playwright
     from playwright.sync_api import TimeoutError as PlaywrightTimeout
 except ImportError:  # pragma: no cover
-    sys.exit(
-        "playwright is not installed. Run:\n"
-        "    pip install playwright && playwright install chromium"
-    )
+    Page = Any
+    PlaywrightTimeout = TimeoutError
+    sync_playwright = None
+
+from listing_catalog import BROWSER_PROBES, REPO_SLUG, SKILL_NAME, BrowserProbeSpec
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCREENSHOT_DIR = REPO_ROOT / "dist" / "listing-checks"
 
-REPO_SLUG = "backblaze-labs/claude-skill-b2-cloud-storage"
-SKILL_NAME = "b2-cloud-storage"
-
-# Phrases we accept as proof of listing. Any one match flips status to "live".
-# Bare "backblaze" was too broad — query echoes ("matching 'backblaze'") tripped it.
-MATCH_TERMS = (
-    "backblaze-labs/claude-skill-b2-cloud-storage",
-    "claude-skill-b2-cloud-storage",
-    "b2-cloud-storage",
-)
-
 Status = Literal["live", "not_found", "error", "blocked"]
-
-# Selectors tried in order when a probe needs interactive search. The first
-# locator that becomes visible wins. Add per-probe overrides via Probe.search_locators.
-DEFAULT_SEARCH_LOCATORS: tuple[str, ...] = (
-    "input[type='search']",
-    "[role='searchbox']",
-    "input[placeholder*='Search' i]",
-    "input[name='q']",
-    "input[name='query']",
-    "input[aria-label*='Search' i]",
-)
-
-
-@dataclass
-class Probe:
-    name: str
-    url: str
-    # Optional CSS/text selector to wait for before sampling page content.
-    # Leave None to use `networkidle`.
-    wait_for: str | None = None
-    # Force-fail on these terms appearing (e.g. captcha, "no results found").
-    negative_terms: tuple[str, ...] = ()
-    # Per-probe override of the default match terms.
-    match_terms: tuple[str, ...] = MATCH_TERMS
-    # Some directories block headless / unknown UAs. Set True to use a longer timeout.
-    slow: bool = False
-    # If set, navigate to `url` (no query string), then type this term into a
-    # search input and press Enter. Use for SPAs that ignore `?q=` URL params.
-    search_query: str | None = None
-    # Override search input selectors when the defaults miss.
-    search_locators: tuple[str, ...] = DEFAULT_SEARCH_LOCATORS
 
 
 @dataclass
@@ -103,177 +62,7 @@ class Result:
     extras: dict[str, str] = field(default_factory=dict)
 
 
-PROBES: tuple[Probe, ...] = (
-    # URL-query directories (their `?q=` filters server-side or via SPA router)
-    Probe(
-        "SkillsMP",
-        "https://skillsmp.com/?q=backblaze",
-        negative_terms=("No skills found",),
-    ),
-    Probe(
-        "SkillsLLM",
-        "https://skillsllm.com/?q=backblaze",
-        negative_terms=("No results", "Nothing found"),
-    ),
-    Probe(
-        "LobeHub Skills",
-        "https://lobehub.com/skills?q=backblaze",
-        negative_terms=("No skills found",),
-    ),
-    Probe(
-        "Pawgrammer Skills Market",
-        "https://skills.pawgrammer.com/?q=backblaze",
-        negative_terms=("No skills found", "couldn't find any skills"),
-    ),
-    # Interactive-search directories (homepage `?q=` is ignored; type into search box)
-    # Claude Marketplaces homepage has no free-text search input — only category
-    # browsing and email subscribe forms. Best signal we can get without a known
-    # canonical URL is checking if `b2-cloud-storage` appears anywhere on the
-    # rendered listings page.
-    Probe(
-        "Claude Marketplaces",
-        "https://claudemarketplaces.com/",
-        negative_terms=("No marketplaces found", "0 results"),
-    ),
-    # ClaudeSkills.info /skills exposes no input element. Their homepage may
-    # have a header search; try that instead.
-    Probe(
-        "ClaudeSkills.info",
-        "https://claudeskills.info/",
-        search_query="backblaze",
-        slow=True,
-        negative_terms=("No skills found",),
-    ),
-    Probe(
-        "Agent Skills Market",
-        "https://www.agentskillsmarket.space/",
-        search_query="backblaze",
-        negative_terms=("No skills found", "0 results"),
-    ),
-    Probe(
-        "SkillHub",
-        "https://skillhub.club/",
-        search_query="backblaze",
-        # Their search input is `type='text'` with placeholder "Search Skills..." —
-        # the generic locators miss the no-`type=search` case, so list it explicitly.
-        search_locators=(
-            "input[placeholder='Search Skills...' i]",
-            "input[placeholder*='Search Skills' i]",
-            *DEFAULT_SEARCH_LOCATORS,
-        ),
-        negative_terms=("No results", "No skills"),
-    ),
-    # Direct text probe — no UI involved
-    Probe(
-        "Awesome Claude Skills",
-        "https://raw.githubusercontent.com/travisvn/awesome-claude-skills/main/README.md",
-        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-    ),
-    Probe(
-        "Awesome Claude Plugins",
-        "https://raw.githubusercontent.com/Chat2AnyLLM/awesome-claude-plugins/main/README.md",
-        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-    ),
-    Probe(
-        "Awesome Agent Skills",
-        "https://raw.githubusercontent.com/heilcheng/awesome-agent-skills/main/README.md",
-        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-    ),
-    # Anthropic's official directories
-    Probe(
-        "Anthropic claude-plugins-official",
-        "https://raw.githubusercontent.com/anthropics/claude-plugins-official/main/README.md",
-        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage", "backblaze"),
-    ),
-    Probe(
-        "Anthropic skills",
-        "https://raw.githubusercontent.com/anthropics/skills/main/README.md",
-        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage", "backblaze"),
-    ),
-    Probe(
-        "claude.com Skills",
-        "https://claude.com/skills?q=backblaze",
-        slow=True,
-        negative_terms=("No skills found", "0 results"),
-    ),
-    # WordPress-style search (?s=)
-    Probe(
-        "Cult of Claude",
-        "https://cultofclaude.com/skills/?s=backblaze",
-        negative_terms=("Nothing Found", "Sorry, but nothing matched"),
-    ),
-    # Community marketplaces — also crawl GitHub topics
-    Probe(
-        "alirezarezvani/claude-skills",
-        "https://raw.githubusercontent.com/alirezarezvani/claude-skills/main/README.md",
-        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-    ),
-    Probe(
-        "daymade/claude-code-skills",
-        "https://raw.githubusercontent.com/daymade/claude-code-skills/main/README.md",
-        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-    ),
-    Probe(
-        "mhattingpete/claude-skills-marketplace",
-        "https://raw.githubusercontent.com/mhattingpete/claude-skills-marketplace/main/README.md",
-        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-    ),
-    # Tier-1 aggregators added 2026-05. Raw README grep — no JS needed but kept
-    # here for parity with the rest of the directory list and one-stop reporting.
-    Probe(
-        "VoltAgent/awesome-agent-skills",
-        "https://raw.githubusercontent.com/VoltAgent/awesome-agent-skills/main/README.md",
-        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-    ),
-    Probe(
-        "hesreallyhim/awesome-claude-code",
-        "https://raw.githubusercontent.com/hesreallyhim/awesome-claude-code/main/README.md",
-        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-    ),
-    Probe(
-        "ComposioHQ/awesome-claude-skills",
-        # Default branch is `master`, not `main`.
-        "https://raw.githubusercontent.com/ComposioHQ/awesome-claude-skills/master/README.md",
-        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-    ),
-    Probe(
-        "netresearch/claude-code-marketplace",
-        # The manifest is the authoritative listing; README may lag.
-        "https://raw.githubusercontent.com/netresearch/claude-code-marketplace/main/.claude-plugin/marketplace.json",
-        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage", "b2-cloud-storage"),
-    ),
-    # Tier-2 community lists
-    Probe(
-        "rohitg00/awesome-claude-code-toolkit",
-        "https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolkit/main/README.md",
-        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-    ),
-    Probe(
-        "BehiSecc/awesome-claude-skills",
-        "https://raw.githubusercontent.com/BehiSecc/awesome-claude-skills/main/README.md",
-        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-    ),
-    Probe(
-        "jqueryscript/awesome-claude-code",
-        "https://raw.githubusercontent.com/jqueryscript/awesome-claude-code/main/README.md",
-        match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-    ),
-    # SPA aggregators — must use Playwright (mcpmarket 403s plain curl, awesomeclaude
-    # is a Next.js site that hydrates client-side).
-    Probe(
-        "MCP Market — Skills",
-        "https://mcpmarket.com/tools/skills?q=backblaze",
-        slow=True,
-        negative_terms=("No skills found", "No results", "0 results"),
-    ),
-    Probe(
-        "awesomeclaude.ai",
-        "https://awesomeclaude.ai/awesome-claude-skills",
-        search_query="backblaze",
-        slow=True,
-        negative_terms=("No skills found", "No results"),
-    ),
-)
+PROBES = BROWSER_PROBES
 
 
 def _snippet_around(text: str, term: str, span: int = 80) -> str:
@@ -286,7 +75,7 @@ def _snippet_around(text: str, term: str, span: int = 80) -> str:
     return re.sub(r"\s+", " ", text[start:end]).strip()
 
 
-def _check_page_text(text: str, probe: Probe) -> tuple[Status, str | None, str | None]:
+def _check_page_text(text: str, probe: BrowserProbeSpec) -> tuple[Status, str | None, str | None]:
     """Return (status, matched_term, snippet) for the rendered text."""
     haystack = text.lower()
     for neg in probe.negative_terms:
@@ -328,7 +117,7 @@ def _dismiss_overlays(page: Page) -> None:
             continue
 
 
-def _interactive_search(page: Page, probe: Probe) -> str | None:
+def _interactive_search(page: Page, probe: BrowserProbeSpec) -> str | None:
     """Find a search input, type the query, press Enter. Returns the locator
     that worked (for debugging) or None if all candidates failed."""
     if not probe.search_query:
@@ -351,7 +140,36 @@ def _interactive_search(page: Page, probe: Probe) -> str | None:
     return None
 
 
-def run_probe(page: Page, probe: Probe, save_screenshots: bool) -> Result:
+def _safe_filename(name: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "_", name).strip("._")
+    return safe or "probe"
+
+
+def screenshot_path_for_probe(name: str) -> Path:
+    return SCREENSHOT_DIR / f"{_safe_filename(name)}.png"
+
+
+def _normalized_filter(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip().lower())
+
+
+def filter_probes(
+    probes: tuple[BrowserProbeSpec, ...], only: list[str] | None
+) -> list[BrowserProbeSpec]:
+    if not only:
+        return list(probes)
+    wanted = {_normalized_filter(name) for name in only}
+    return [
+        probe
+        for probe in probes
+        if any(
+            want == _normalized_filter(probe.name) or want in _normalized_filter(probe.name)
+            for want in wanted
+        )
+    ]
+
+
+def run_probe(page: Page, probe: BrowserProbeSpec, save_screenshots: bool) -> Result:
     started = datetime.now(timezone.utc)
     result = Result(name=probe.name, url=probe.url, status="error")
     try:
@@ -397,7 +215,7 @@ def run_probe(page: Page, probe: Probe, save_screenshots: bool) -> Result:
     finally:
         if save_screenshots and probe.url.startswith("http") and result.status != "error":
             SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
-            path = SCREENSHOT_DIR / f"{probe.name.replace(' ', '_')}.png"
+            path = screenshot_path_for_probe(probe.name)
             try:
                 page.screenshot(path=str(path), full_page=True)
                 result.screenshot = str(path.relative_to(REPO_ROOT))
@@ -450,13 +268,18 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    probes: list[Probe] = list(PROBES)
-    if args.only:
-        wanted = {n.lower() for n in args.only}
-        probes = [p for p in probes if p.name.lower() in wanted]
-        if not probes:
-            print(f"No matching probes for --only {args.only}", file=sys.stderr)
-            return 2
+    probes = filter_probes(PROBES, args.only)
+    if not probes:
+        print(f"No matching probes for --only {args.only}", file=sys.stderr)
+        return 2
+
+    if sync_playwright is None:
+        print(
+            "playwright is not installed. Run:\n"
+            "    pip install playwright && playwright install chromium",
+            file=sys.stderr,
+        )
+        return 2
 
     results: list[Result] = []
     with sync_playwright() as pw:

--- a/scripts/check_listings_api.py
+++ b/scripts/check_listings_api.py
@@ -107,7 +107,7 @@ def _read_limited_body(response: object, *, max_bytes: int, deadline: float) -> 
             raise ResponseTooLarge(msg)
 
 
-def _http_get(
+def http_get_limited(
     url: str,
     *,
     headers: dict[str, str] | None = None,
@@ -115,6 +115,7 @@ def _http_get(
     max_bytes: int = MAX_RESPONSE_BYTES,
     total_timeout: float = HTTP_TOTAL_TIMEOUT_SECONDS,
 ) -> tuple[int, str, dict[str, str]]:
+    """Fetch a URL with bounded response size and total body-read time."""
     req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT, **(headers or {})})
     deadline = time.monotonic() + total_timeout
     try:
@@ -175,7 +176,7 @@ def check_github_repo(
     last_detail = "unknown error"
     for attempt in range(1, attempts + 1):
         try:
-            code, body, _ = _http_get(url, headers=headers)
+            code, body, _ = http_get_limited(url, headers=headers)
             if code != 200:
                 last_detail = f"HTTP {code}"
                 if attempt < attempts and _is_retryable_status(code):
@@ -227,7 +228,7 @@ def check_text_probe(probe: HttpProbeSpec) -> Result:
     """Fetch a URL, grep for any of `terms`."""
     started = datetime.now(timezone.utc)
     try:
-        code, body, _ = _http_get(probe.url)
+        code, body, _ = http_get_limited(probe.url)
         elapsed = _elapsed_ms(started)
         if code >= 400:
             return Result(

--- a/scripts/check_listings_api.py
+++ b/scripts/check_listings_api.py
@@ -79,6 +79,17 @@ class Result:
     extras: dict[str, object] = field(default_factory=dict)
 
 
+def _set_response_read_timeout(response: object, timeout: float) -> None:
+    current = response
+    for attr in ("fp", "raw", "_sock"):
+        current = getattr(current, attr, None)
+        if current is None:
+            return
+    settimeout = getattr(current, "settimeout", None)
+    if callable(settimeout):
+        settimeout(max(timeout, 0.001))
+
+
 def _read_limited_body(response: object, *, max_bytes: int, deadline: float) -> bytes:
     headers = getattr(response, "headers", {})
     content_length = headers.get("Content-Length") if headers else None
@@ -94,8 +105,10 @@ def _read_limited_body(response: object, *, max_bytes: int, deadline: float) -> 
     chunks: list[bytes] = []
     total = 0
     while True:
-        if time.monotonic() > deadline:
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds <= 0:
             raise TimeoutError("response read deadline exceeded")
+        _set_response_read_timeout(response, remaining_seconds)
         read_size = min(READ_CHUNK_BYTES, max_bytes + 1 - total)
         chunk = response.read(read_size)
         if not chunk:

--- a/scripts/check_listings_api.py
+++ b/scripts/check_listings_api.py
@@ -26,8 +26,7 @@ Usage::
 Exit codes:
   0 — every probe completed (live or not_found, no errors)
   1 — at least one probe errored (network, HTTP 5xx, etc.)
-  2 — ``--strict`` is set and a hard expectation failed (e.g. repo missing
-      required topics)
+  2 — required GitHub topics are missing, or ``--strict`` cannot verify them
 """
 
 from __future__ import annotations
@@ -36,6 +35,7 @@ import argparse
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.request
 from dataclasses import asdict, dataclass, field
@@ -43,24 +43,29 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
-REPO_SLUG = "backblaze-labs/claude-skill-b2-cloud-storage"
-SKILL_NAME = "b2-cloud-storage"
+from listing_catalog import HTTP_PROBES, REPO_SLUG, SKILL_NAME, HttpProbeSpec
 
 # Topics that drive marketplace auto-discovery. Missing any of these is a
 # concrete, fixable cause of "we're not listed anywhere."
 EXPECTED_TOPICS = ("skillsmp", "claude-skill", "agent-skill", "claude-code")
-
-MATCH_TERMS = (
-    REPO_SLUG.lower(),
-    "claude-skill-b2-cloud-storage",
-)
 
 USER_AGENT = (
     "claude-skill-b2-cloud-storage-listing-check/1.0 "
     "(+https://github.com/backblaze-labs/claude-skill-b2-cloud-storage)"
 )
 
+READ_CHUNK_BYTES = 64 * 1024
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 15.0
+HTTP_TOTAL_TIMEOUT_SECONDS = 20.0
+GITHUB_RETRY_ATTEMPTS = 3
+GITHUB_RETRY_BACKOFF_SECONDS = (1.0, 2.0)
+
 Status = Literal["live", "not_found", "error", "missing_topic"]
+
+
+class ResponseTooLarge(ValueError):
+    """Raised when an HTTP response exceeds the configured body cap."""
 
 
 @dataclass
@@ -74,16 +79,56 @@ class Result:
     extras: dict[str, object] = field(default_factory=dict)
 
 
+def _read_limited_body(response: object, *, max_bytes: int, deadline: float) -> bytes:
+    headers = getattr(response, "headers", {})
+    content_length = headers.get("Content-Length") if headers else None
+    if content_length:
+        try:
+            if int(content_length) > max_bytes:
+                msg = f"Content-Length {content_length} exceeds {max_bytes} byte limit"
+                raise ResponseTooLarge(msg)
+        except ValueError as exc:
+            if isinstance(exc, ResponseTooLarge):
+                raise
+
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        if time.monotonic() > deadline:
+            raise TimeoutError("response read deadline exceeded")
+        read_size = min(READ_CHUNK_BYTES, max_bytes + 1 - total)
+        chunk = response.read(read_size)
+        if not chunk:
+            return b"".join(chunks)
+        chunks.append(chunk)
+        total += len(chunk)
+        if total > max_bytes:
+            msg = f"response exceeded {max_bytes} byte limit"
+            raise ResponseTooLarge(msg)
+
+
 def _http_get(
-    url: str, *, headers: dict[str, str] | None = None, timeout: int = 15
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    timeout: float = HTTP_TIMEOUT_SECONDS,
+    max_bytes: int = MAX_RESPONSE_BYTES,
+    total_timeout: float = HTTP_TOTAL_TIMEOUT_SECONDS,
 ) -> tuple[int, str, dict[str, str]]:
     req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT, **(headers or {})})
+    deadline = time.monotonic() + total_timeout
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            body = resp.read().decode("utf-8", errors="replace")
+            body = _read_limited_body(resp, max_bytes=max_bytes, deadline=deadline).decode(
+                "utf-8", errors="replace"
+            )
             return resp.status, body, dict(resp.headers)
     except urllib.error.HTTPError as e:
-        body = e.read().decode("utf-8", errors="replace") if e.fp else ""
+        body = ""
+        if e.fp:
+            body = _read_limited_body(e, max_bytes=max_bytes, deadline=deadline).decode(
+                "utf-8", errors="replace"
+            )
         return e.code, body, dict(e.headers or {})
 
 
@@ -95,7 +140,29 @@ def _scan(text: str, terms: tuple[str, ...]) -> str | None:
     return None
 
 
-def check_github_repo() -> Result:
+def _elapsed_ms(started: datetime) -> int:
+    return int((datetime.now(timezone.utc) - started).total_seconds() * 1000)
+
+
+def _is_retryable_status(code: int) -> bool:
+    return code in (403, 429) or code >= 500
+
+
+def _github_error_result(started: datetime, detail: str) -> Result:
+    return Result(
+        "GitHub repo metadata",
+        f"https://api.github.com/repos/{REPO_SLUG}",
+        "error",
+        detail=f"GitHub metadata unavailable: {detail}",
+        duration_ms=_elapsed_ms(started),
+    )
+
+
+def check_github_repo(
+    *,
+    attempts: int = GITHUB_RETRY_ATTEMPTS,
+    backoff_seconds: tuple[float, ...] = GITHUB_RETRY_BACKOFF_SECONDS,
+) -> Result:
     """Hit api.github.com for repo metadata. Flags missing topics."""
     started = datetime.now(timezone.utc)
     name = "GitHub repo metadata"
@@ -104,159 +171,84 @@ def check_github_repo() -> Result:
     token = os.environ.get("GITHUB_TOKEN")
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    try:
-        code, body, _ = _http_get(url, headers=headers)
-        elapsed = int((datetime.now(timezone.utc) - started).total_seconds() * 1000)
-        if code != 200:
-            return Result(name, url, "error", detail=f"HTTP {code}", duration_ms=elapsed)
-        data = json.loads(body)
-        topics = tuple(data.get("topics") or ())
-        missing = tuple(t for t in EXPECTED_TOPICS if t not in topics)
-        extras: dict[str, object] = {
-            "stars": data.get("stargazers_count"),
-            "forks": data.get("forks_count"),
-            "archived": data.get("archived"),
-            "default_branch": data.get("default_branch"),
-            "topics": topics,
-            "missing_topics": missing,
-            "description": data.get("description"),
-        }
-        if missing:
+
+    last_detail = "unknown error"
+    for attempt in range(1, attempts + 1):
+        try:
+            code, body, _ = _http_get(url, headers=headers)
+            if code != 200:
+                last_detail = f"HTTP {code}"
+                if attempt < attempts and _is_retryable_status(code):
+                    time.sleep(backoff_seconds[min(attempt - 1, len(backoff_seconds) - 1)])
+                    continue
+                return _github_error_result(started, last_detail)
+
+            data = json.loads(body)
+            topics = tuple(data.get("topics") or ())
+            missing = tuple(t for t in EXPECTED_TOPICS if t not in topics)
+            extras: dict[str, object] = {
+                "stars": data.get("stargazers_count"),
+                "forks": data.get("forks_count"),
+                "archived": data.get("archived"),
+                "default_branch": data.get("default_branch"),
+                "topics": topics,
+                "missing_topics": missing,
+                "description": data.get("description"),
+                "attempts": attempt,
+            }
+            if missing:
+                return Result(
+                    name,
+                    url,
+                    "missing_topic",
+                    detail=f"missing topics: {', '.join(missing)}",
+                    duration_ms=_elapsed_ms(started),
+                    extras=extras,
+                )
             return Result(
                 name,
                 url,
-                "missing_topic",
-                detail=f"missing topics: {', '.join(missing)}",
-                duration_ms=elapsed,
+                "live",
+                detail=f"{data.get('stargazers_count', 0)}★ • topics ok",
+                duration_ms=_elapsed_ms(started),
                 extras=extras,
             )
-        return Result(
-            name,
-            url,
-            "live",
-            detail=f"{data.get('stargazers_count', 0)}★ • topics ok",
-            duration_ms=elapsed,
-            extras=extras,
-        )
-    except (urllib.error.URLError, TimeoutError, ValueError) as exc:
-        elapsed = int((datetime.now(timezone.utc) - started).total_seconds() * 1000)
-        return Result(
-            name, url, "error", detail=f"{type(exc).__name__}: {exc}", duration_ms=elapsed
-        )
+        except (urllib.error.URLError, TimeoutError, ValueError) as exc:
+            last_detail = f"{type(exc).__name__}: {exc}"
+            if attempt < attempts:
+                time.sleep(backoff_seconds[min(attempt - 1, len(backoff_seconds) - 1)])
+                continue
+            return _github_error_result(started, last_detail)
+
+    return _github_error_result(started, last_detail)
 
 
-def check_text_probe(name: str, url: str, terms: tuple[str, ...] = MATCH_TERMS) -> Result:
+def check_text_probe(probe: HttpProbeSpec) -> Result:
     """Fetch a URL, grep for any of `terms`."""
     started = datetime.now(timezone.utc)
     try:
-        code, body, _ = _http_get(url)
-        elapsed = int((datetime.now(timezone.utc) - started).total_seconds() * 1000)
+        code, body, _ = _http_get(probe.url)
+        elapsed = _elapsed_ms(started)
         if code >= 400:
-            return Result(name, url, "error", detail=f"HTTP {code}", duration_ms=elapsed)
-        matched = _scan(body, terms)
+            return Result(
+                probe.name, probe.url, "error", detail=f"HTTP {code}", duration_ms=elapsed
+            )
+        matched = _scan(body, probe.match_terms)
         if matched:
-            return Result(name, url, "live", matched_term=matched, duration_ms=elapsed)
-        return Result(name, url, "not_found", duration_ms=elapsed)
-    except (urllib.error.URLError, TimeoutError) as exc:
-        elapsed = int((datetime.now(timezone.utc) - started).total_seconds() * 1000)
+            return Result(probe.name, probe.url, "live", matched_term=matched, duration_ms=elapsed)
+        return Result(probe.name, probe.url, "not_found", duration_ms=elapsed)
+    except (urllib.error.URLError, TimeoutError, ResponseTooLarge) as exc:
+        elapsed = _elapsed_ms(started)
         return Result(
-            name, url, "error", detail=f"{type(exc).__name__}: {exc}", duration_ms=elapsed
+            probe.name,
+            probe.url,
+            "error",
+            detail=f"{type(exc).__name__}: {exc}",
+            duration_ms=elapsed,
         )
 
 
-# Probes that are fully checkable via plain HTTP (text grep). For SPAs,
-# defer to scripts/check_listings.py.
-TEXT_PROBES: tuple[tuple[str, str], ...] = (
-    # Awesome lists
-    (
-        "Awesome Claude Skills (travisvn)",
-        "https://raw.githubusercontent.com/travisvn/awesome-claude-skills/main/README.md",
-    ),
-    (
-        "Awesome Claude Plugins (Chat2AnyLLM)",
-        "https://raw.githubusercontent.com/Chat2AnyLLM/awesome-claude-plugins/main/README.md",
-    ),
-    (
-        "Awesome Agent Skills (heilcheng)",
-        "https://raw.githubusercontent.com/heilcheng/awesome-agent-skills/main/README.md",
-    ),
-    # Anthropic-managed directories
-    (
-        "Anthropic claude-plugins-official",
-        "https://raw.githubusercontent.com/anthropics/claude-plugins-official/main/README.md",
-    ),
-    (
-        "Anthropic skills",
-        "https://raw.githubusercontent.com/anthropics/skills/main/README.md",
-    ),
-    # Community marketplaces with public READMEs
-    (
-        "alirezarezvani/claude-skills",
-        "https://raw.githubusercontent.com/alirezarezvani/claude-skills/main/README.md",
-    ),
-    (
-        "daymade/claude-code-skills",
-        "https://raw.githubusercontent.com/daymade/claude-code-skills/main/README.md",
-    ),
-    (
-        "mhattingpete/claude-skills-marketplace",
-        "https://raw.githubusercontent.com/mhattingpete/claude-skills-marketplace/main/README.md",
-    ),
-    # Tier-1 aggregators added 2026-05 — verified default branches per repo.
-    # ComposioHQ uses `master`; everyone else here uses `main`.
-    (
-        "VoltAgent/awesome-agent-skills",
-        "https://raw.githubusercontent.com/VoltAgent/awesome-agent-skills/main/README.md",
-    ),
-    (
-        "hesreallyhim/awesome-claude-code",
-        "https://raw.githubusercontent.com/hesreallyhim/awesome-claude-code/main/README.md",
-    ),
-    (
-        "ComposioHQ/awesome-claude-skills",
-        "https://raw.githubusercontent.com/ComposioHQ/awesome-claude-skills/master/README.md",
-    ),
-    (
-        "netresearch/claude-code-marketplace (README)",
-        "https://raw.githubusercontent.com/netresearch/claude-code-marketplace/main/README.md",
-    ),
-    # The marketplace.json is the authoritative source — README may lag.
-    (
-        "netresearch/claude-code-marketplace (manifest)",
-        "https://raw.githubusercontent.com/netresearch/claude-code-marketplace/main/.claude-plugin/marketplace.json",
-    ),
-    # Tier-2 community lists
-    (
-        "rohitg00/awesome-claude-code-toolkit",
-        "https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolkit/main/README.md",
-    ),
-    (
-        "BehiSecc/awesome-claude-skills",
-        "https://raw.githubusercontent.com/BehiSecc/awesome-claude-skills/main/README.md",
-    ),
-    (
-        "jqueryscript/awesome-claude-code",
-        "https://raw.githubusercontent.com/jqueryscript/awesome-claude-code/main/README.md",
-    ),
-    # SPAs — best-effort HTML grep. May produce false negatives if listings
-    # are rendered client-side; trust the Playwright probe for those.
-    (
-        "SkillsMP (HTML)",
-        "https://skillsmp.com/?q=backblaze",
-    ),
-    (
-        "LobeHub Skills (HTML)",
-        "https://lobehub.com/skills?q=backblaze",
-    ),
-    (
-        "Claude Marketplaces (HTML)",
-        "https://claudemarketplaces.com/",
-    ),
-    (
-        "Cult of Claude (HTML)",
-        "https://cultofclaude.com/skills/?s=backblaze",
-    ),
-)
+TEXT_PROBES = HTTP_PROBES
 
 
 def render_markdown(results: list[Result]) -> str:
@@ -293,6 +285,17 @@ def render_markdown(results: list[Result]) -> str:
     return "\n".join(lines)
 
 
+def strict_topic_failures(results: list[Result]) -> list[str]:
+    github = next((r for r in results if r.name == "GitHub repo metadata"), None)
+    if github is None:
+        return ["GitHub metadata result missing from probe output"]
+    if github.status == "missing_topic":
+        return [github.detail or "required GitHub discovery topics are missing"]
+    if github.status == "error":
+        return [github.detail or "GitHub metadata probe failed"]
+    return []
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
@@ -302,14 +305,17 @@ def main() -> int:
     parser.add_argument(
         "--strict",
         action="store_true",
-        help="Exit nonzero on missing GitHub topics (in addition to errors)",
+        help=(
+            "Exit nonzero when the GitHub metadata probe is unavailable or required "
+            "topics are missing; third-party marketplace errors remain report-only"
+        ),
     )
     args = parser.parse_args()
 
     results: list[Result] = [check_github_repo()]
-    for name, url in TEXT_PROBES:
-        print(f"  → {name}  …  ", end="", flush=True, file=sys.stderr)
-        r = check_text_probe(name, url)
+    for probe in TEXT_PROBES:
+        print(f"  → {probe.name}  …  ", end="", flush=True, file=sys.stderr)
+        r = check_text_probe(probe)
         results.append(r)
         tag = r.matched_term or r.detail or "—"
         print(f"{r.status}  ({r.duration_ms}ms)  {tag}", file=sys.stderr)
@@ -323,11 +329,17 @@ def main() -> int:
         args.report.parent.mkdir(parents=True, exist_ok=True)
         args.report.write_text(md + "\n", encoding="utf-8")
 
+    if args.strict:
+        failures = strict_topic_failures(results)
+        for failure in failures:
+            print(f"::error::{failure}", file=sys.stderr)
+        return 2 if failures else 0
+
     has_error = any(r.status == "error" for r in results)
     has_missing_topic = any(r.status == "missing_topic" for r in results)
     if has_error:
         return 1
-    if args.strict and has_missing_topic:
+    if has_missing_topic:
         return 2
     return 0
 

--- a/scripts/check_listings_api.py
+++ b/scripts/check_listings_api.py
@@ -21,7 +21,7 @@ Usage::
     python scripts/check_listings_api.py
     python scripts/check_listings_api.py --json
     python scripts/check_listings_api.py --report dist/listings-api.md
-    GITHUB_TOKEN=ghp_... python scripts/check_listings_api.py     # higher rate limits
+    GITHUB_TOKEN=your-token python scripts/check_listings_api.py  # higher rate limits
 
 Exit codes:
   0 — every probe completed (live or not_found, no errors)

--- a/scripts/check_listings_api.py
+++ b/scripts/check_listings_api.py
@@ -80,19 +80,29 @@ class Result:
 
 
 def _set_response_read_timeout(response: object, timeout: float) -> None:
-    current = response
-    for attr in ("fp", "raw", "_sock"):
-        current = getattr(current, attr, None)
-        if current is None:
-            return
-    settimeout = getattr(current, "settimeout", None)
-    if callable(settimeout):
-        settimeout(max(timeout, 0.001))
+    for attr_path in (("fp", "raw", "_sock"), ("raw", "_sock"), ("_sock",)):
+        current = response
+        for attr in attr_path:
+            current = getattr(current, attr, None)
+            if current is None:
+                break
+        else:
+            settimeout = getattr(current, "settimeout", None)
+            if callable(settimeout):
+                settimeout(max(timeout, 0.001))
+                return
 
 
-def _read_limited_body(response: object, *, max_bytes: int, deadline: float) -> bytes:
-    headers = getattr(response, "headers", {})
-    content_length = headers.get("Content-Length") if headers else None
+def _read_limited_body(
+    response: object,
+    *,
+    max_bytes: int,
+    deadline: float,
+    headers: object | None = None,
+) -> bytes:
+    response_headers = headers if headers is not None else getattr(response, "headers", None)
+    header_get = getattr(response_headers, "get", None)
+    content_length = header_get("Content-Length") if callable(header_get) else None
     if content_length:
         try:
             if int(content_length) > max_bytes:
@@ -140,9 +150,12 @@ def http_get_limited(
     except urllib.error.HTTPError as e:
         body = ""
         if e.fp:
-            body = _read_limited_body(e, max_bytes=max_bytes, deadline=deadline).decode(
-                "utf-8", errors="replace"
-            )
+            body = _read_limited_body(
+                e.fp,
+                max_bytes=max_bytes,
+                deadline=deadline,
+                headers=e.headers,
+            ).decode("utf-8", errors="replace")
         return e.code, body, dict(e.headers or {})
 
 

--- a/scripts/check_listings_api.py
+++ b/scripts/check_listings_api.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Pure-stdlib listing check — fast, no browser, suitable for CI / cron.
+
+Companion to ``check_listings.py``. The Playwright script is the source of
+truth for SPA-rendered marketplace pages; this script covers everything that
+can be checked with plain HTTP:
+
+  * GitHub repo metadata for ``backblaze-labs/claude-skill-b2-cloud-storage``
+    (topics, stars, archived flag, latest release) — answers "did anyone
+    forget to add the ``skillsmp`` topic?"
+  * Raw README of every awesome-list / community marketplace that aggregates
+    skills from GitHub. Plain text grep — zero false positives.
+  * Anthropic's official skills/plugins directories (raw README).
+  * SkillsMP, LobeHub, claudemarketplaces.com landing pages — best-effort
+    HTML grep. SPAs may hydrate after first paint, so a "not_found" here
+    means "almost certainly not listed" but trust the Playwright probe for
+    final confirmation.
+
+Usage::
+
+    python scripts/check_listings_api.py
+    python scripts/check_listings_api.py --json
+    python scripts/check_listings_api.py --report dist/listings-api.md
+    GITHUB_TOKEN=ghp_... python scripts/check_listings_api.py     # higher rate limits
+
+Exit codes:
+  0 — every probe completed (live or not_found, no errors)
+  1 — at least one probe errored (network, HTTP 5xx, etc.)
+  2 — a hard expectation failed (e.g. repo missing required topics)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+REPO_SLUG = "backblaze-labs/claude-skill-b2-cloud-storage"
+SKILL_NAME = "b2-cloud-storage"
+
+# Topics that drive marketplace auto-discovery. Missing any of these is a
+# concrete, fixable cause of "we're not listed anywhere."
+EXPECTED_TOPICS = ("skillsmp", "claude-skill", "agent-skill", "claude-code")
+
+MATCH_TERMS = (
+    REPO_SLUG.lower(),
+    "claude-skill-b2-cloud-storage",
+)
+
+USER_AGENT = (
+    "claude-skill-b2-cloud-storage-listing-check/1.0 "
+    "(+https://github.com/backblaze-labs/claude-skill-b2-cloud-storage)"
+)
+
+Status = Literal["live", "not_found", "error", "missing_topic"]
+
+
+@dataclass
+class Result:
+    name: str
+    url: str
+    status: Status
+    detail: str | None = None
+    matched_term: str | None = None
+    duration_ms: int = 0
+    extras: dict[str, object] = field(default_factory=dict)
+
+
+def _http_get(
+    url: str, *, headers: dict[str, str] | None = None, timeout: int = 15
+) -> tuple[int, str, dict[str, str]]:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT, **(headers or {})})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            return resp.status, body, dict(resp.headers)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace") if e.fp else ""
+        return e.code, body, dict(e.headers or {})
+
+
+def _scan(text: str, terms: tuple[str, ...]) -> str | None:
+    haystack = text.lower()
+    for term in terms:
+        if term.lower() in haystack:
+            return term
+    return None
+
+
+def check_github_repo() -> Result:
+    """Hit api.github.com for repo metadata. Flags missing topics."""
+    started = datetime.now(timezone.utc)
+    name = "GitHub repo metadata"
+    url = f"https://api.github.com/repos/{REPO_SLUG}"
+    headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        code, body, _ = _http_get(url, headers=headers)
+        elapsed = int((datetime.now(timezone.utc) - started).total_seconds() * 1000)
+        if code != 200:
+            return Result(name, url, "error", detail=f"HTTP {code}", duration_ms=elapsed)
+        data = json.loads(body)
+        topics = tuple(data.get("topics") or ())
+        missing = tuple(t for t in EXPECTED_TOPICS if t not in topics)
+        extras: dict[str, object] = {
+            "stars": data.get("stargazers_count"),
+            "forks": data.get("forks_count"),
+            "archived": data.get("archived"),
+            "default_branch": data.get("default_branch"),
+            "topics": topics,
+            "missing_topics": missing,
+            "description": data.get("description"),
+        }
+        if missing:
+            return Result(
+                name,
+                url,
+                "missing_topic",
+                detail=f"missing topics: {', '.join(missing)}",
+                duration_ms=elapsed,
+                extras=extras,
+            )
+        return Result(
+            name,
+            url,
+            "live",
+            detail=f"{data.get('stargazers_count', 0)}★ • topics ok",
+            duration_ms=elapsed,
+            extras=extras,
+        )
+    except (urllib.error.URLError, TimeoutError, ValueError) as exc:
+        elapsed = int((datetime.now(timezone.utc) - started).total_seconds() * 1000)
+        return Result(
+            name, url, "error", detail=f"{type(exc).__name__}: {exc}", duration_ms=elapsed
+        )
+
+
+def check_text_probe(name: str, url: str, terms: tuple[str, ...] = MATCH_TERMS) -> Result:
+    """Fetch a URL, grep for any of `terms`."""
+    started = datetime.now(timezone.utc)
+    try:
+        code, body, _ = _http_get(url)
+        elapsed = int((datetime.now(timezone.utc) - started).total_seconds() * 1000)
+        if code >= 400:
+            return Result(name, url, "error", detail=f"HTTP {code}", duration_ms=elapsed)
+        matched = _scan(body, terms)
+        if matched:
+            return Result(name, url, "live", matched_term=matched, duration_ms=elapsed)
+        return Result(name, url, "not_found", duration_ms=elapsed)
+    except (urllib.error.URLError, TimeoutError) as exc:
+        elapsed = int((datetime.now(timezone.utc) - started).total_seconds() * 1000)
+        return Result(
+            name, url, "error", detail=f"{type(exc).__name__}: {exc}", duration_ms=elapsed
+        )
+
+
+# Probes that are fully checkable via plain HTTP (text grep). For SPAs,
+# defer to scripts/check_listings.py.
+TEXT_PROBES: tuple[tuple[str, str], ...] = (
+    # Awesome lists
+    (
+        "Awesome Claude Skills (travisvn)",
+        "https://raw.githubusercontent.com/travisvn/awesome-claude-skills/main/README.md",
+    ),
+    (
+        "Awesome Claude Plugins (Chat2AnyLLM)",
+        "https://raw.githubusercontent.com/Chat2AnyLLM/awesome-claude-plugins/main/README.md",
+    ),
+    (
+        "Awesome Agent Skills (heilcheng)",
+        "https://raw.githubusercontent.com/heilcheng/awesome-agent-skills/main/README.md",
+    ),
+    # Anthropic-managed directories
+    (
+        "Anthropic claude-plugins-official",
+        "https://raw.githubusercontent.com/anthropics/claude-plugins-official/main/README.md",
+    ),
+    (
+        "Anthropic skills",
+        "https://raw.githubusercontent.com/anthropics/skills/main/README.md",
+    ),
+    # Community marketplaces with public READMEs
+    (
+        "alirezarezvani/claude-skills",
+        "https://raw.githubusercontent.com/alirezarezvani/claude-skills/main/README.md",
+    ),
+    (
+        "daymade/claude-code-skills",
+        "https://raw.githubusercontent.com/daymade/claude-code-skills/main/README.md",
+    ),
+    (
+        "mhattingpete/claude-skills-marketplace",
+        "https://raw.githubusercontent.com/mhattingpete/claude-skills-marketplace/main/README.md",
+    ),
+    # Tier-1 aggregators added 2026-05 — verified default branches per repo.
+    # ComposioHQ uses `master`; everyone else here uses `main`.
+    (
+        "VoltAgent/awesome-agent-skills",
+        "https://raw.githubusercontent.com/VoltAgent/awesome-agent-skills/main/README.md",
+    ),
+    (
+        "hesreallyhim/awesome-claude-code",
+        "https://raw.githubusercontent.com/hesreallyhim/awesome-claude-code/main/README.md",
+    ),
+    (
+        "ComposioHQ/awesome-claude-skills",
+        "https://raw.githubusercontent.com/ComposioHQ/awesome-claude-skills/master/README.md",
+    ),
+    (
+        "netresearch/claude-code-marketplace (README)",
+        "https://raw.githubusercontent.com/netresearch/claude-code-marketplace/main/README.md",
+    ),
+    # The marketplace.json is the authoritative source — README may lag.
+    (
+        "netresearch/claude-code-marketplace (manifest)",
+        "https://raw.githubusercontent.com/netresearch/claude-code-marketplace/main/.claude-plugin/marketplace.json",
+    ),
+    # Tier-2 community lists
+    (
+        "rohitg00/awesome-claude-code-toolkit",
+        "https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolkit/main/README.md",
+    ),
+    (
+        "BehiSecc/awesome-claude-skills",
+        "https://raw.githubusercontent.com/BehiSecc/awesome-claude-skills/main/README.md",
+    ),
+    (
+        "jqueryscript/awesome-claude-code",
+        "https://raw.githubusercontent.com/jqueryscript/awesome-claude-code/main/README.md",
+    ),
+    # SPAs — best-effort HTML grep. May produce false negatives if listings
+    # are rendered client-side; trust the Playwright probe for those.
+    (
+        "SkillsMP (HTML)",
+        "https://skillsmp.com/?q=backblaze",
+    ),
+    (
+        "LobeHub Skills (HTML)",
+        "https://lobehub.com/skills?q=backblaze",
+    ),
+    (
+        "Claude Marketplaces (HTML)",
+        "https://claudemarketplaces.com/",
+    ),
+    (
+        "Cult of Claude (HTML)",
+        "https://cultofclaude.com/skills/?s=backblaze",
+    ),
+)
+
+
+def render_markdown(results: list[Result]) -> str:
+    icon = {"live": "✅", "not_found": "❌", "error": "⚠️", "missing_topic": "🏷️"}
+    lines = [
+        f"# Listing status (HTTP-only) — {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}",
+        f"Repo: `{REPO_SLUG}`  •  Skill: `{SKILL_NAME}`",
+        "",
+        "| Source | Status | Detail |",
+        "|---|---|---|",
+    ]
+    for r in results:
+        detail = r.detail or (f"matched: {r.matched_term}" if r.matched_term else "—")
+        if len(detail) > 90:
+            detail = detail[:87] + "…"
+        lines.append(f"| {r.name} | {icon.get(r.status, '?')} {r.status} | {detail} |")
+
+    live = sum(1 for r in results if r.status == "live")
+    missing_topics = next((r for r in results if r.status == "missing_topic"), None)
+    lines += ["", f"**{live}/{len(results)} live.**"]
+    if missing_topics and isinstance(missing_topics.extras.get("missing_topics"), tuple):
+        missing = missing_topics.extras["missing_topics"]
+        if missing:
+            lines += [
+                "",
+                "## Missing GitHub topics",
+                "",
+                "Add these topics to the repo to unlock auto-discovery on aggregators:",
+                "",
+                *(f"- `{t}`" for t in missing),
+                "",
+                'GitHub: Settings → "manage topics" on the repo landing page.',
+            ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of markdown")
+    parser.add_argument("--report", type=Path, help="Also write the markdown report to this path")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit nonzero on missing GitHub topics (in addition to errors)",
+    )
+    args = parser.parse_args()
+
+    results: list[Result] = [check_github_repo()]
+    for name, url in TEXT_PROBES:
+        print(f"  → {name}  …  ", end="", flush=True, file=sys.stderr)
+        r = check_text_probe(name, url)
+        results.append(r)
+        tag = r.matched_term or r.detail or "—"
+        print(f"{r.status}  ({r.duration_ms}ms)  {tag}", file=sys.stderr)
+
+    md = render_markdown(results)
+    if args.json:
+        print(json.dumps([asdict(r) for r in results], indent=2, default=str))
+    else:
+        print(md)
+    if args.report:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(md + "\n", encoding="utf-8")
+
+    has_error = any(r.status == "error" for r in results)
+    has_missing_topic = any(r.status == "missing_topic" for r in results)
+    if has_error:
+        return 1
+    if args.strict and has_missing_topic:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_listings_api.py
+++ b/scripts/check_listings_api.py
@@ -6,8 +6,8 @@ truth for SPA-rendered marketplace pages; this script covers everything that
 can be checked with plain HTTP:
 
   * GitHub repo metadata for ``backblaze-labs/claude-skill-b2-cloud-storage``
-    (topics, stars, archived flag, latest release) — answers "did anyone
-    forget to add the ``skillsmp`` topic?"
+    (topics, stars, archived flag) — answers "did anyone forget to add the
+    ``skillsmp`` topic?"
   * Raw README of every awesome-list / community marketplace that aggregates
     skills from GitHub. Plain text grep — zero false positives.
   * Anthropic's official skills/plugins directories (raw README).
@@ -26,7 +26,8 @@ Usage::
 Exit codes:
   0 — every probe completed (live or not_found, no errors)
   1 — at least one probe errored (network, HTTP 5xx, etc.)
-  2 — a hard expectation failed (e.g. repo missing required topics)
+  2 — ``--strict`` is set and a hard expectation failed (e.g. repo missing
+      required topics)
 """
 
 from __future__ import annotations

--- a/scripts/listing_catalog.py
+++ b/scripts/listing_catalog.py
@@ -54,306 +54,265 @@ class MarketplaceProbe:
     browser: BrowserProbeSpec | None = None
 
 
+RAW_MATCH_TERMS = (REPO_SLUG, "claude-skill-b2-cloud-storage")
+
+
+def http_only(
+    key: str,
+    name: str,
+    url: str,
+    *,
+    match_terms: tuple[str, ...] = HTTP_MATCH_TERMS,
+) -> MarketplaceProbe:
+    return MarketplaceProbe(key=key, http=HttpProbeSpec(name, url, match_terms=match_terms))
+
+
+def browser_only(
+    key: str,
+    name: str,
+    url: str,
+    *,
+    wait_for: str | None = None,
+    negative_terms: tuple[str, ...] = (),
+    match_terms: tuple[str, ...] = BROWSER_MATCH_TERMS,
+    slow: bool = False,
+    search_query: str | None = None,
+    search_locators: tuple[str, ...] = DEFAULT_SEARCH_LOCATORS,
+) -> MarketplaceProbe:
+    return MarketplaceProbe(
+        key=key,
+        browser=BrowserProbeSpec(
+            name,
+            url,
+            wait_for=wait_for,
+            negative_terms=negative_terms,
+            match_terms=match_terms,
+            slow=slow,
+            search_query=search_query,
+            search_locators=search_locators,
+        ),
+    )
+
+
+def shared_probe(
+    key: str,
+    name: str,
+    url: str,
+    *,
+    http_name: str | None = None,
+    browser_name: str | None = None,
+    http_match_terms: tuple[str, ...] = HTTP_MATCH_TERMS,
+    browser_match_terms: tuple[str, ...] = BROWSER_MATCH_TERMS,
+    wait_for: str | None = None,
+    negative_terms: tuple[str, ...] = (),
+    slow: bool = False,
+    search_query: str | None = None,
+    search_locators: tuple[str, ...] = DEFAULT_SEARCH_LOCATORS,
+) -> MarketplaceProbe:
+    return MarketplaceProbe(
+        key=key,
+        http=HttpProbeSpec(http_name or name, url, match_terms=http_match_terms),
+        browser=BrowserProbeSpec(
+            browser_name or name,
+            url,
+            wait_for=wait_for,
+            negative_terms=negative_terms,
+            match_terms=browser_match_terms,
+            slow=slow,
+            search_query=search_query,
+            search_locators=search_locators,
+        ),
+    )
+
+
 MARKETPLACE_PROBES: tuple[MarketplaceProbe, ...] = (
-    MarketplaceProbe(
-        key="skillsmp",
-        http=HttpProbeSpec("SkillsMP (HTML)", "https://skillsmp.com/?q=backblaze"),
-        browser=BrowserProbeSpec(
-            "SkillsMP",
-            "https://skillsmp.com/?q=backblaze",
-            negative_terms=("No skills found",),
-        ),
+    shared_probe(
+        "skillsmp",
+        "SkillsMP",
+        "https://skillsmp.com/?q=backblaze",
+        http_name="SkillsMP (HTML)",
+        negative_terms=("No skills found",),
     ),
-    MarketplaceProbe(
-        key="skillsllm",
-        browser=BrowserProbeSpec(
-            "SkillsLLM",
-            "https://skillsllm.com/?q=backblaze",
-            negative_terms=("No results", "Nothing found"),
-        ),
+    browser_only(
+        "skillsllm",
+        "SkillsLLM",
+        "https://skillsllm.com/?q=backblaze",
+        negative_terms=("No results", "Nothing found"),
     ),
-    MarketplaceProbe(
-        key="lobehub-skills",
-        http=HttpProbeSpec("LobeHub Skills (HTML)", "https://lobehub.com/skills?q=backblaze"),
-        browser=BrowserProbeSpec(
-            "LobeHub Skills",
-            "https://lobehub.com/skills?q=backblaze",
-            negative_terms=("No skills found",),
-        ),
+    shared_probe(
+        "lobehub-skills",
+        "LobeHub Skills",
+        "https://lobehub.com/skills?q=backblaze",
+        http_name="LobeHub Skills (HTML)",
+        negative_terms=("No skills found",),
     ),
-    MarketplaceProbe(
-        key="pawgrammer-skills-market",
-        browser=BrowserProbeSpec(
-            "Pawgrammer Skills Market",
-            "https://skills.pawgrammer.com/?q=backblaze",
-            negative_terms=("No skills found", "couldn't find any skills"),
-        ),
+    browser_only(
+        "pawgrammer-skills-market",
+        "Pawgrammer Skills Market",
+        "https://skills.pawgrammer.com/?q=backblaze",
+        negative_terms=("No skills found", "couldn't find any skills"),
     ),
-    MarketplaceProbe(
-        key="claude-marketplaces",
-        http=HttpProbeSpec("Claude Marketplaces (HTML)", "https://claudemarketplaces.com/"),
-        browser=BrowserProbeSpec(
-            "Claude Marketplaces",
-            "https://claudemarketplaces.com/",
-            negative_terms=("No marketplaces found", "0 results"),
-        ),
+    shared_probe(
+        "claude-marketplaces",
+        "Claude Marketplaces",
+        "https://claudemarketplaces.com/",
+        http_name="Claude Marketplaces (HTML)",
+        negative_terms=("No marketplaces found", "0 results"),
     ),
-    MarketplaceProbe(
-        key="claudeskills-info",
-        browser=BrowserProbeSpec(
-            "ClaudeSkills.info",
-            "https://claudeskills.info/",
-            search_query="backblaze",
-            slow=True,
-            negative_terms=("No skills found",),
-        ),
+    browser_only(
+        "claudeskills-info",
+        "ClaudeSkills.info",
+        "https://claudeskills.info/",
+        search_query="backblaze",
+        slow=True,
+        negative_terms=("No skills found",),
     ),
-    MarketplaceProbe(
-        key="agent-skills-market",
-        browser=BrowserProbeSpec(
-            "Agent Skills Market",
-            "https://www.agentskillsmarket.space/",
-            search_query="backblaze",
-            negative_terms=("No skills found", "0 results"),
-        ),
+    browser_only(
+        "agent-skills-market",
+        "Agent Skills Market",
+        "https://www.agentskillsmarket.space/",
+        search_query="backblaze",
+        negative_terms=("No skills found", "0 results"),
     ),
-    MarketplaceProbe(
-        key="skillhub",
-        browser=BrowserProbeSpec(
-            "SkillHub",
-            "https://skillhub.club/",
-            search_query="backblaze",
-            search_locators=(
-                "input[placeholder='Search Skills...' i]",
-                "input[placeholder*='Search Skills' i]",
-                *DEFAULT_SEARCH_LOCATORS,
-            ),
-            negative_terms=("No results", "No skills"),
+    browser_only(
+        "skillhub",
+        "SkillHub",
+        "https://skillhub.club/",
+        search_query="backblaze",
+        search_locators=(
+            "input[placeholder='Search Skills...' i]",
+            "input[placeholder*='Search Skills' i]",
+            *DEFAULT_SEARCH_LOCATORS,
         ),
+        negative_terms=("No results", "No skills"),
     ),
-    MarketplaceProbe(
-        key="awesome-claude-skills-travisvn",
-        http=HttpProbeSpec(
-            "Awesome Claude Skills (travisvn)",
-            "https://raw.githubusercontent.com/travisvn/awesome-claude-skills/main/README.md",
-        ),
-        browser=BrowserProbeSpec(
-            "Awesome Claude Skills",
-            "https://raw.githubusercontent.com/travisvn/awesome-claude-skills/main/README.md",
-            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-        ),
+    shared_probe(
+        "awesome-claude-skills-travisvn",
+        "Awesome Claude Skills",
+        "https://raw.githubusercontent.com/travisvn/awesome-claude-skills/main/README.md",
+        http_name="Awesome Claude Skills (travisvn)",
+        browser_match_terms=RAW_MATCH_TERMS,
     ),
-    MarketplaceProbe(
-        key="awesome-claude-plugins-chat2anyllm",
-        http=HttpProbeSpec(
-            "Awesome Claude Plugins (Chat2AnyLLM)",
-            "https://raw.githubusercontent.com/Chat2AnyLLM/awesome-claude-plugins/main/README.md",
-        ),
-        browser=BrowserProbeSpec(
-            "Awesome Claude Plugins",
-            "https://raw.githubusercontent.com/Chat2AnyLLM/awesome-claude-plugins/main/README.md",
-            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-        ),
+    shared_probe(
+        "awesome-claude-plugins-chat2anyllm",
+        "Awesome Claude Plugins",
+        "https://raw.githubusercontent.com/Chat2AnyLLM/awesome-claude-plugins/main/README.md",
+        http_name="Awesome Claude Plugins (Chat2AnyLLM)",
+        browser_match_terms=RAW_MATCH_TERMS,
     ),
-    MarketplaceProbe(
-        key="awesome-agent-skills-heilcheng",
-        http=HttpProbeSpec(
-            "Awesome Agent Skills (heilcheng)",
-            "https://raw.githubusercontent.com/heilcheng/awesome-agent-skills/main/README.md",
-        ),
-        browser=BrowserProbeSpec(
-            "Awesome Agent Skills",
-            "https://raw.githubusercontent.com/heilcheng/awesome-agent-skills/main/README.md",
-            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-        ),
+    shared_probe(
+        "awesome-agent-skills-heilcheng",
+        "Awesome Agent Skills",
+        "https://raw.githubusercontent.com/heilcheng/awesome-agent-skills/main/README.md",
+        http_name="Awesome Agent Skills (heilcheng)",
+        browser_match_terms=RAW_MATCH_TERMS,
     ),
-    MarketplaceProbe(
-        key="anthropic-claude-plugins-official",
-        http=HttpProbeSpec(
-            "Anthropic claude-plugins-official",
-            "https://raw.githubusercontent.com/anthropics/claude-plugins-official/main/README.md",
-        ),
-        browser=BrowserProbeSpec(
-            "Anthropic claude-plugins-official",
-            "https://raw.githubusercontent.com/anthropics/claude-plugins-official/main/README.md",
-            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage", "backblaze"),
-        ),
+    shared_probe(
+        "anthropic-claude-plugins-official",
+        "Anthropic claude-plugins-official",
+        "https://raw.githubusercontent.com/anthropics/claude-plugins-official/main/README.md",
+        browser_match_terms=(*RAW_MATCH_TERMS, "backblaze"),
     ),
-    MarketplaceProbe(
-        key="anthropic-skills",
-        http=HttpProbeSpec(
-            "Anthropic skills",
-            "https://raw.githubusercontent.com/anthropics/skills/main/README.md",
-        ),
-        browser=BrowserProbeSpec(
-            "Anthropic skills",
-            "https://raw.githubusercontent.com/anthropics/skills/main/README.md",
-            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage", "backblaze"),
-        ),
+    shared_probe(
+        "anthropic-skills",
+        "Anthropic skills",
+        "https://raw.githubusercontent.com/anthropics/skills/main/README.md",
+        browser_match_terms=(*RAW_MATCH_TERMS, "backblaze"),
     ),
-    MarketplaceProbe(
-        key="claude-com-skills",
-        browser=BrowserProbeSpec(
-            "claude.com Skills",
-            "https://claude.com/skills?q=backblaze",
-            slow=True,
-            negative_terms=("No skills found", "0 results"),
-        ),
+    browser_only(
+        "claude-com-skills",
+        "claude.com Skills",
+        "https://claude.com/skills?q=backblaze",
+        slow=True,
+        negative_terms=("No skills found", "0 results"),
     ),
-    MarketplaceProbe(
-        key="cult-of-claude",
-        http=HttpProbeSpec("Cult of Claude (HTML)", "https://cultofclaude.com/skills/?s=backblaze"),
-        browser=BrowserProbeSpec(
-            "Cult of Claude",
-            "https://cultofclaude.com/skills/?s=backblaze",
-            negative_terms=("Nothing Found", "Sorry, but nothing matched"),
-        ),
+    shared_probe(
+        "cult-of-claude",
+        "Cult of Claude",
+        "https://cultofclaude.com/skills/?s=backblaze",
+        http_name="Cult of Claude (HTML)",
+        negative_terms=("Nothing Found", "Sorry, but nothing matched"),
     ),
-    MarketplaceProbe(
-        key="alirezarezvani-claude-skills",
-        http=HttpProbeSpec(
-            "alirezarezvani/claude-skills",
-            "https://raw.githubusercontent.com/alirezarezvani/claude-skills/main/README.md",
-        ),
-        browser=BrowserProbeSpec(
-            "alirezarezvani/claude-skills",
-            "https://raw.githubusercontent.com/alirezarezvani/claude-skills/main/README.md",
-            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-        ),
+    shared_probe(
+        "alirezarezvani-claude-skills",
+        "alirezarezvani/claude-skills",
+        "https://raw.githubusercontent.com/alirezarezvani/claude-skills/main/README.md",
+        browser_match_terms=RAW_MATCH_TERMS,
     ),
-    MarketplaceProbe(
-        key="daymade-claude-code-skills",
-        http=HttpProbeSpec(
-            "daymade/claude-code-skills",
-            "https://raw.githubusercontent.com/daymade/claude-code-skills/main/README.md",
-        ),
-        browser=BrowserProbeSpec(
-            "daymade/claude-code-skills",
-            "https://raw.githubusercontent.com/daymade/claude-code-skills/main/README.md",
-            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-        ),
+    shared_probe(
+        "daymade-claude-code-skills",
+        "daymade/claude-code-skills",
+        "https://raw.githubusercontent.com/daymade/claude-code-skills/main/README.md",
+        browser_match_terms=RAW_MATCH_TERMS,
     ),
-    MarketplaceProbe(
-        key="mhattingpete-claude-skills-marketplace",
-        http=HttpProbeSpec(
-            "mhattingpete/claude-skills-marketplace",
-            "https://raw.githubusercontent.com/mhattingpete/claude-skills-marketplace/main/README.md",
-        ),
-        browser=BrowserProbeSpec(
-            "mhattingpete/claude-skills-marketplace",
-            "https://raw.githubusercontent.com/mhattingpete/claude-skills-marketplace/main/README.md",
-            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-        ),
+    shared_probe(
+        "mhattingpete-claude-skills-marketplace",
+        "mhattingpete/claude-skills-marketplace",
+        "https://raw.githubusercontent.com/mhattingpete/claude-skills-marketplace/main/README.md",
+        browser_match_terms=RAW_MATCH_TERMS,
     ),
-    MarketplaceProbe(
-        key="voltagent-awesome-agent-skills",
-        http=HttpProbeSpec(
-            "VoltAgent/awesome-agent-skills",
-            "https://raw.githubusercontent.com/VoltAgent/awesome-agent-skills/main/README.md",
-        ),
-        browser=BrowserProbeSpec(
-            "VoltAgent/awesome-agent-skills",
-            "https://raw.githubusercontent.com/VoltAgent/awesome-agent-skills/main/README.md",
-            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-        ),
+    shared_probe(
+        "voltagent-awesome-agent-skills",
+        "VoltAgent/awesome-agent-skills",
+        "https://raw.githubusercontent.com/VoltAgent/awesome-agent-skills/main/README.md",
+        browser_match_terms=RAW_MATCH_TERMS,
     ),
-    MarketplaceProbe(
-        key="hesreallyhim-awesome-claude-code",
-        http=HttpProbeSpec(
-            "hesreallyhim/awesome-claude-code",
-            "https://raw.githubusercontent.com/hesreallyhim/awesome-claude-code/main/README.md",
-        ),
-        browser=BrowserProbeSpec(
-            "hesreallyhim/awesome-claude-code",
-            "https://raw.githubusercontent.com/hesreallyhim/awesome-claude-code/main/README.md",
-            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-        ),
+    shared_probe(
+        "hesreallyhim-awesome-claude-code",
+        "hesreallyhim/awesome-claude-code",
+        "https://raw.githubusercontent.com/hesreallyhim/awesome-claude-code/main/README.md",
+        browser_match_terms=RAW_MATCH_TERMS,
     ),
-    MarketplaceProbe(
-        key="composiohq-awesome-claude-skills",
-        http=HttpProbeSpec(
-            "ComposioHQ/awesome-claude-skills",
-            "https://raw.githubusercontent.com/ComposioHQ/awesome-claude-skills/master/README.md",
-        ),
-        browser=BrowserProbeSpec(
-            "ComposioHQ/awesome-claude-skills",
-            "https://raw.githubusercontent.com/ComposioHQ/awesome-claude-skills/master/README.md",
-            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-        ),
+    shared_probe(
+        "composiohq-awesome-claude-skills",
+        "ComposioHQ/awesome-claude-skills",
+        "https://raw.githubusercontent.com/ComposioHQ/awesome-claude-skills/master/README.md",
+        browser_match_terms=RAW_MATCH_TERMS,
     ),
-    MarketplaceProbe(
-        key="netresearch-claude-code-marketplace-readme",
-        http=HttpProbeSpec(
-            "netresearch/claude-code-marketplace (README)",
-            "https://raw.githubusercontent.com/netresearch/claude-code-marketplace/main/README.md",
-        ),
+    http_only(
+        "netresearch-claude-code-marketplace-readme",
+        "netresearch/claude-code-marketplace (README)",
+        "https://raw.githubusercontent.com/netresearch/claude-code-marketplace/main/README.md",
     ),
-    MarketplaceProbe(
-        key="netresearch-claude-code-marketplace-manifest",
-        http=HttpProbeSpec(
-            "netresearch/claude-code-marketplace (manifest)",
-            "https://raw.githubusercontent.com/netresearch/claude-code-marketplace/main/.claude-plugin/marketplace.json",
-        ),
-        browser=BrowserProbeSpec(
-            "netresearch/claude-code-marketplace",
-            "https://raw.githubusercontent.com/netresearch/claude-code-marketplace/main/.claude-plugin/marketplace.json",
-            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage", "b2-cloud-storage"),
-        ),
+    shared_probe(
+        "netresearch-claude-code-marketplace-manifest",
+        "netresearch/claude-code-marketplace",
+        "https://raw.githubusercontent.com/netresearch/claude-code-marketplace/main/.claude-plugin/marketplace.json",
+        http_name="netresearch/claude-code-marketplace (manifest)",
+        browser_match_terms=(*RAW_MATCH_TERMS, "b2-cloud-storage"),
     ),
-    MarketplaceProbe(
-        key="rohitg00-awesome-claude-code-toolkit",
-        http=HttpProbeSpec(
-            "rohitg00/awesome-claude-code-toolkit",
-            "https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolkit/main/README.md",
-        ),
-        browser=BrowserProbeSpec(
-            "rohitg00/awesome-claude-code-toolkit",
-            "https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolkit/main/README.md",
-            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-        ),
+    shared_probe(
+        "rohitg00-awesome-claude-code-toolkit",
+        "rohitg00/awesome-claude-code-toolkit",
+        "https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolkit/main/README.md",
+        browser_match_terms=RAW_MATCH_TERMS,
     ),
-    MarketplaceProbe(
-        key="behisecc-awesome-claude-skills",
-        http=HttpProbeSpec(
-            "BehiSecc/awesome-claude-skills",
-            "https://raw.githubusercontent.com/BehiSecc/awesome-claude-skills/main/README.md",
-        ),
-        browser=BrowserProbeSpec(
-            "BehiSecc/awesome-claude-skills",
-            "https://raw.githubusercontent.com/BehiSecc/awesome-claude-skills/main/README.md",
-            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-        ),
+    shared_probe(
+        "behisecc-awesome-claude-skills",
+        "BehiSecc/awesome-claude-skills",
+        "https://raw.githubusercontent.com/BehiSecc/awesome-claude-skills/main/README.md",
+        browser_match_terms=RAW_MATCH_TERMS,
     ),
-    MarketplaceProbe(
-        key="jqueryscript-awesome-claude-code",
-        http=HttpProbeSpec(
-            "jqueryscript/awesome-claude-code",
-            "https://raw.githubusercontent.com/jqueryscript/awesome-claude-code/main/README.md",
-        ),
-        browser=BrowserProbeSpec(
-            "jqueryscript/awesome-claude-code",
-            "https://raw.githubusercontent.com/jqueryscript/awesome-claude-code/main/README.md",
-            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
-        ),
+    shared_probe(
+        "jqueryscript-awesome-claude-code",
+        "jqueryscript/awesome-claude-code",
+        "https://raw.githubusercontent.com/jqueryscript/awesome-claude-code/main/README.md",
+        browser_match_terms=RAW_MATCH_TERMS,
     ),
-    MarketplaceProbe(
-        key="mcp-market-skills",
-        browser=BrowserProbeSpec(
-            "MCP Market — Skills",
-            "https://mcpmarket.com/tools/skills?q=backblaze",
-            slow=True,
-            negative_terms=("No skills found", "No results", "0 results"),
-        ),
+    browser_only(
+        "mcp-market-skills",
+        "MCP Market — Skills",
+        "https://mcpmarket.com/tools/skills?q=backblaze",
+        slow=True,
+        negative_terms=("No skills found", "No results", "0 results"),
     ),
-    MarketplaceProbe(
-        key="awesomeclaude-ai",
-        browser=BrowserProbeSpec(
-            "awesomeclaude.ai",
-            "https://awesomeclaude.ai/awesome-claude-skills",
-            search_query="backblaze",
-            slow=True,
-            negative_terms=("No skills found", "No results"),
-        ),
+    browser_only(
+        "awesomeclaude-ai",
+        "awesomeclaude.ai",
+        "https://awesomeclaude.ai/awesome-claude-skills",
+        search_query="backblaze",
+        slow=True,
+        negative_terms=("No skills found", "No results"),
     ),
 )
 

--- a/scripts/listing_catalog.py
+++ b/scripts/listing_catalog.py
@@ -1,0 +1,366 @@
+"""Canonical marketplace probe definitions shared by the listing checkers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+REPO_SLUG = "backblaze-labs/claude-skill-b2-cloud-storage"
+SKILL_NAME = "b2-cloud-storage"
+
+HTTP_MATCH_TERMS = (
+    REPO_SLUG.lower(),
+    "claude-skill-b2-cloud-storage",
+)
+
+BROWSER_MATCH_TERMS = (
+    "backblaze-labs/claude-skill-b2-cloud-storage",
+    "claude-skill-b2-cloud-storage",
+    "b2-cloud-storage",
+)
+
+DEFAULT_SEARCH_LOCATORS = (
+    "input[type='search']",
+    "[role='searchbox']",
+    "input[placeholder*='Search' i]",
+    "input[name='q']",
+    "input[name='query']",
+    "input[aria-label*='Search' i]",
+)
+
+
+@dataclass(frozen=True)
+class HttpProbeSpec:
+    name: str
+    url: str
+    match_terms: tuple[str, ...] = HTTP_MATCH_TERMS
+
+
+@dataclass(frozen=True)
+class BrowserProbeSpec:
+    name: str
+    url: str
+    wait_for: str | None = None
+    negative_terms: tuple[str, ...] = ()
+    match_terms: tuple[str, ...] = BROWSER_MATCH_TERMS
+    slow: bool = False
+    search_query: str | None = None
+    search_locators: tuple[str, ...] = DEFAULT_SEARCH_LOCATORS
+
+
+@dataclass(frozen=True)
+class MarketplaceProbe:
+    key: str
+    http: HttpProbeSpec | None = None
+    browser: BrowserProbeSpec | None = None
+
+
+MARKETPLACE_PROBES: tuple[MarketplaceProbe, ...] = (
+    MarketplaceProbe(
+        key="skillsmp",
+        http=HttpProbeSpec("SkillsMP (HTML)", "https://skillsmp.com/?q=backblaze"),
+        browser=BrowserProbeSpec(
+            "SkillsMP",
+            "https://skillsmp.com/?q=backblaze",
+            negative_terms=("No skills found",),
+        ),
+    ),
+    MarketplaceProbe(
+        key="skillsllm",
+        browser=BrowserProbeSpec(
+            "SkillsLLM",
+            "https://skillsllm.com/?q=backblaze",
+            negative_terms=("No results", "Nothing found"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="lobehub-skills",
+        http=HttpProbeSpec("LobeHub Skills (HTML)", "https://lobehub.com/skills?q=backblaze"),
+        browser=BrowserProbeSpec(
+            "LobeHub Skills",
+            "https://lobehub.com/skills?q=backblaze",
+            negative_terms=("No skills found",),
+        ),
+    ),
+    MarketplaceProbe(
+        key="pawgrammer-skills-market",
+        browser=BrowserProbeSpec(
+            "Pawgrammer Skills Market",
+            "https://skills.pawgrammer.com/?q=backblaze",
+            negative_terms=("No skills found", "couldn't find any skills"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="claude-marketplaces",
+        http=HttpProbeSpec("Claude Marketplaces (HTML)", "https://claudemarketplaces.com/"),
+        browser=BrowserProbeSpec(
+            "Claude Marketplaces",
+            "https://claudemarketplaces.com/",
+            negative_terms=("No marketplaces found", "0 results"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="claudeskills-info",
+        browser=BrowserProbeSpec(
+            "ClaudeSkills.info",
+            "https://claudeskills.info/",
+            search_query="backblaze",
+            slow=True,
+            negative_terms=("No skills found",),
+        ),
+    ),
+    MarketplaceProbe(
+        key="agent-skills-market",
+        browser=BrowserProbeSpec(
+            "Agent Skills Market",
+            "https://www.agentskillsmarket.space/",
+            search_query="backblaze",
+            negative_terms=("No skills found", "0 results"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="skillhub",
+        browser=BrowserProbeSpec(
+            "SkillHub",
+            "https://skillhub.club/",
+            search_query="backblaze",
+            search_locators=(
+                "input[placeholder='Search Skills...' i]",
+                "input[placeholder*='Search Skills' i]",
+                *DEFAULT_SEARCH_LOCATORS,
+            ),
+            negative_terms=("No results", "No skills"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="awesome-claude-skills-travisvn",
+        http=HttpProbeSpec(
+            "Awesome Claude Skills (travisvn)",
+            "https://raw.githubusercontent.com/travisvn/awesome-claude-skills/main/README.md",
+        ),
+        browser=BrowserProbeSpec(
+            "Awesome Claude Skills",
+            "https://raw.githubusercontent.com/travisvn/awesome-claude-skills/main/README.md",
+            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="awesome-claude-plugins-chat2anyllm",
+        http=HttpProbeSpec(
+            "Awesome Claude Plugins (Chat2AnyLLM)",
+            "https://raw.githubusercontent.com/Chat2AnyLLM/awesome-claude-plugins/main/README.md",
+        ),
+        browser=BrowserProbeSpec(
+            "Awesome Claude Plugins",
+            "https://raw.githubusercontent.com/Chat2AnyLLM/awesome-claude-plugins/main/README.md",
+            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="awesome-agent-skills-heilcheng",
+        http=HttpProbeSpec(
+            "Awesome Agent Skills (heilcheng)",
+            "https://raw.githubusercontent.com/heilcheng/awesome-agent-skills/main/README.md",
+        ),
+        browser=BrowserProbeSpec(
+            "Awesome Agent Skills",
+            "https://raw.githubusercontent.com/heilcheng/awesome-agent-skills/main/README.md",
+            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="anthropic-claude-plugins-official",
+        http=HttpProbeSpec(
+            "Anthropic claude-plugins-official",
+            "https://raw.githubusercontent.com/anthropics/claude-plugins-official/main/README.md",
+        ),
+        browser=BrowserProbeSpec(
+            "Anthropic claude-plugins-official",
+            "https://raw.githubusercontent.com/anthropics/claude-plugins-official/main/README.md",
+            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage", "backblaze"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="anthropic-skills",
+        http=HttpProbeSpec(
+            "Anthropic skills",
+            "https://raw.githubusercontent.com/anthropics/skills/main/README.md",
+        ),
+        browser=BrowserProbeSpec(
+            "Anthropic skills",
+            "https://raw.githubusercontent.com/anthropics/skills/main/README.md",
+            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage", "backblaze"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="claude-com-skills",
+        browser=BrowserProbeSpec(
+            "claude.com Skills",
+            "https://claude.com/skills?q=backblaze",
+            slow=True,
+            negative_terms=("No skills found", "0 results"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="cult-of-claude",
+        http=HttpProbeSpec("Cult of Claude (HTML)", "https://cultofclaude.com/skills/?s=backblaze"),
+        browser=BrowserProbeSpec(
+            "Cult of Claude",
+            "https://cultofclaude.com/skills/?s=backblaze",
+            negative_terms=("Nothing Found", "Sorry, but nothing matched"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="alirezarezvani-claude-skills",
+        http=HttpProbeSpec(
+            "alirezarezvani/claude-skills",
+            "https://raw.githubusercontent.com/alirezarezvani/claude-skills/main/README.md",
+        ),
+        browser=BrowserProbeSpec(
+            "alirezarezvani/claude-skills",
+            "https://raw.githubusercontent.com/alirezarezvani/claude-skills/main/README.md",
+            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="daymade-claude-code-skills",
+        http=HttpProbeSpec(
+            "daymade/claude-code-skills",
+            "https://raw.githubusercontent.com/daymade/claude-code-skills/main/README.md",
+        ),
+        browser=BrowserProbeSpec(
+            "daymade/claude-code-skills",
+            "https://raw.githubusercontent.com/daymade/claude-code-skills/main/README.md",
+            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="mhattingpete-claude-skills-marketplace",
+        http=HttpProbeSpec(
+            "mhattingpete/claude-skills-marketplace",
+            "https://raw.githubusercontent.com/mhattingpete/claude-skills-marketplace/main/README.md",
+        ),
+        browser=BrowserProbeSpec(
+            "mhattingpete/claude-skills-marketplace",
+            "https://raw.githubusercontent.com/mhattingpete/claude-skills-marketplace/main/README.md",
+            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="voltagent-awesome-agent-skills",
+        http=HttpProbeSpec(
+            "VoltAgent/awesome-agent-skills",
+            "https://raw.githubusercontent.com/VoltAgent/awesome-agent-skills/main/README.md",
+        ),
+        browser=BrowserProbeSpec(
+            "VoltAgent/awesome-agent-skills",
+            "https://raw.githubusercontent.com/VoltAgent/awesome-agent-skills/main/README.md",
+            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="hesreallyhim-awesome-claude-code",
+        http=HttpProbeSpec(
+            "hesreallyhim/awesome-claude-code",
+            "https://raw.githubusercontent.com/hesreallyhim/awesome-claude-code/main/README.md",
+        ),
+        browser=BrowserProbeSpec(
+            "hesreallyhim/awesome-claude-code",
+            "https://raw.githubusercontent.com/hesreallyhim/awesome-claude-code/main/README.md",
+            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="composiohq-awesome-claude-skills",
+        http=HttpProbeSpec(
+            "ComposioHQ/awesome-claude-skills",
+            "https://raw.githubusercontent.com/ComposioHQ/awesome-claude-skills/master/README.md",
+        ),
+        browser=BrowserProbeSpec(
+            "ComposioHQ/awesome-claude-skills",
+            "https://raw.githubusercontent.com/ComposioHQ/awesome-claude-skills/master/README.md",
+            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="netresearch-claude-code-marketplace-readme",
+        http=HttpProbeSpec(
+            "netresearch/claude-code-marketplace (README)",
+            "https://raw.githubusercontent.com/netresearch/claude-code-marketplace/main/README.md",
+        ),
+    ),
+    MarketplaceProbe(
+        key="netresearch-claude-code-marketplace-manifest",
+        http=HttpProbeSpec(
+            "netresearch/claude-code-marketplace (manifest)",
+            "https://raw.githubusercontent.com/netresearch/claude-code-marketplace/main/.claude-plugin/marketplace.json",
+        ),
+        browser=BrowserProbeSpec(
+            "netresearch/claude-code-marketplace",
+            "https://raw.githubusercontent.com/netresearch/claude-code-marketplace/main/.claude-plugin/marketplace.json",
+            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage", "b2-cloud-storage"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="rohitg00-awesome-claude-code-toolkit",
+        http=HttpProbeSpec(
+            "rohitg00/awesome-claude-code-toolkit",
+            "https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolkit/main/README.md",
+        ),
+        browser=BrowserProbeSpec(
+            "rohitg00/awesome-claude-code-toolkit",
+            "https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolkit/main/README.md",
+            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="behisecc-awesome-claude-skills",
+        http=HttpProbeSpec(
+            "BehiSecc/awesome-claude-skills",
+            "https://raw.githubusercontent.com/BehiSecc/awesome-claude-skills/main/README.md",
+        ),
+        browser=BrowserProbeSpec(
+            "BehiSecc/awesome-claude-skills",
+            "https://raw.githubusercontent.com/BehiSecc/awesome-claude-skills/main/README.md",
+            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="jqueryscript-awesome-claude-code",
+        http=HttpProbeSpec(
+            "jqueryscript/awesome-claude-code",
+            "https://raw.githubusercontent.com/jqueryscript/awesome-claude-code/main/README.md",
+        ),
+        browser=BrowserProbeSpec(
+            "jqueryscript/awesome-claude-code",
+            "https://raw.githubusercontent.com/jqueryscript/awesome-claude-code/main/README.md",
+            match_terms=(REPO_SLUG, "claude-skill-b2-cloud-storage"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="mcp-market-skills",
+        browser=BrowserProbeSpec(
+            "MCP Market — Skills",
+            "https://mcpmarket.com/tools/skills?q=backblaze",
+            slow=True,
+            negative_terms=("No skills found", "No results", "0 results"),
+        ),
+    ),
+    MarketplaceProbe(
+        key="awesomeclaude-ai",
+        browser=BrowserProbeSpec(
+            "awesomeclaude.ai",
+            "https://awesomeclaude.ai/awesome-claude-skills",
+            search_query="backblaze",
+            slow=True,
+            negative_terms=("No skills found", "No results"),
+        ),
+    ),
+)
+
+HTTP_PROBES: tuple[HttpProbeSpec, ...] = tuple(
+    probe.http for probe in MARKETPLACE_PROBES if probe.http is not None
+)
+
+BROWSER_PROBES: tuple[BrowserProbeSpec, ...] = tuple(
+    probe.browser for probe in MARKETPLACE_PROBES if probe.browser is not None
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).parent.parent
 
-# Make repo release tooling and skill scripts importable in tests.
-SCRIPTS = ROOT / "skills" / "b2-cloud-storage" / "scripts"
+# Make repo release tooling and both skill + maintenance scripts importable in tests.
+SKILL_SCRIPTS = ROOT / "skills" / "b2-cloud-storage" / "scripts"
 sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(SCRIPTS))
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(SKILL_SCRIPTS))

--- a/tests/test_listing_checks.py
+++ b/tests/test_listing_checks.py
@@ -59,7 +59,7 @@ def local_probe_server() -> Iterator[str]:
 
 def test_http_get_rejects_oversized_response(local_probe_server: str) -> None:
     with pytest.raises(check_listings_api.ResponseTooLarge):
-        check_listings_api._http_get(
+        check_listings_api.http_get_limited(
             f"{local_probe_server}/large",
             max_bytes=1024,
             timeout=1,
@@ -70,7 +70,7 @@ def test_http_get_rejects_oversized_response(local_probe_server: str) -> None:
 def test_http_get_enforces_total_read_deadline(local_probe_server: str) -> None:
     started = time.monotonic()
     with pytest.raises(TimeoutError):
-        check_listings_api._http_get(
+        check_listings_api.http_get_limited(
             f"{local_probe_server}/slow",
             max_bytes=4096,
             timeout=1,
@@ -102,7 +102,7 @@ def test_github_metadata_retries_before_succeeding(monkeypatch: pytest.MonkeyPat
             {},
         )
 
-    monkeypatch.setattr(check_listings_api, "_http_get", fake_http_get)
+    monkeypatch.setattr(check_listings_api, "http_get_limited", fake_http_get)
     monkeypatch.setattr(check_listings_api.time, "sleep", lambda _seconds: None)
 
     result = check_listings_api.check_github_repo(backoff_seconds=(0.0, 0.0))

--- a/tests/test_listing_checks.py
+++ b/tests/test_listing_checks.py
@@ -25,8 +25,8 @@ class _OversizedAndSlowHandler(BaseHTTPRequestHandler):
                 self.wfile.write(body)
             return
 
-        if self.path == "/slow":
-            self.send_response(200)
+        if self.path in {"/slow", "/slow-error"}:
+            self.send_response(500 if self.path == "/slow-error" else 200)
             self.send_header("Transfer-Encoding", "chunked")
             self.end_headers()
             with contextlib.suppress(BrokenPipeError, ConnectionResetError):
@@ -72,6 +72,20 @@ def test_http_get_enforces_total_read_deadline(local_probe_server: str) -> None:
     with pytest.raises(TimeoutError):
         check_listings_api.http_get_limited(
             f"{local_probe_server}/slow",
+            max_bytes=4096,
+            timeout=1,
+            total_timeout=0.12,
+        )
+    assert time.monotonic() - started < 1
+
+
+def test_http_get_enforces_total_read_deadline_for_error_response(
+    local_probe_server: str,
+) -> None:
+    started = time.monotonic()
+    with pytest.raises(TimeoutError):
+        check_listings_api.http_get_limited(
+            f"{local_probe_server}/slow-error",
             max_bytes=4096,
             timeout=1,
             total_timeout=0.12,

--- a/tests/test_listing_checks.py
+++ b/tests/test_listing_checks.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import contextlib
+import json
+import threading
+import time
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import check_listings
+import check_listings_api
+import listing_catalog
+import pytest
+
+
+class _OversizedAndSlowHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        if self.path == "/large":
+            body = b"x" * 2048
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+                self.wfile.write(body)
+            return
+
+        if self.path == "/slow":
+            self.send_response(200)
+            self.send_header("Transfer-Encoding", "chunked")
+            self.end_headers()
+            with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+                for _ in range(10):
+                    self.wfile.write(b"1\r\nx\r\n")
+                    self.wfile.flush()
+                    time.sleep(0.05)
+                self.wfile.write(b"0\r\n\r\n")
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+@pytest.fixture
+def local_probe_server() -> Iterator[str]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _OversizedAndSlowHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1)
+
+
+def test_http_get_rejects_oversized_response(local_probe_server: str) -> None:
+    with pytest.raises(check_listings_api.ResponseTooLarge):
+        check_listings_api._http_get(
+            f"{local_probe_server}/large",
+            max_bytes=1024,
+            timeout=1,
+            total_timeout=1,
+        )
+
+
+def test_http_get_enforces_total_read_deadline(local_probe_server: str) -> None:
+    started = time.monotonic()
+    with pytest.raises(TimeoutError):
+        check_listings_api._http_get(
+            f"{local_probe_server}/slow",
+            max_bytes=4096,
+            timeout=1,
+            total_timeout=0.12,
+        )
+    assert time.monotonic() - started < 1
+
+
+def test_github_metadata_retries_before_succeeding(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = 0
+
+    def fake_http_get(*_args: object, **_kwargs: object) -> tuple[int, str, dict[str, str]]:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            return 503, "", {}
+        return (
+            200,
+            json.dumps(
+                {
+                    "topics": list(check_listings_api.EXPECTED_TOPICS),
+                    "stargazers_count": 1,
+                    "forks_count": 0,
+                    "archived": False,
+                    "default_branch": "main",
+                    "description": "test repo",
+                }
+            ),
+            {},
+        )
+
+    monkeypatch.setattr(check_listings_api, "_http_get", fake_http_get)
+    monkeypatch.setattr(check_listings_api.time, "sleep", lambda _seconds: None)
+
+    result = check_listings_api.check_github_repo(backoff_seconds=(0.0, 0.0))
+
+    assert attempts == 3
+    assert result.status == "live"
+    assert result.extras["attempts"] == 3
+
+
+def test_strict_topic_failures_include_metadata_errors() -> None:
+    result = check_listings_api.Result(
+        "GitHub repo metadata",
+        "https://api.github.com/repos/example/repo",
+        "error",
+        detail="GitHub metadata unavailable: HTTP 503",
+    )
+
+    assert check_listings_api.strict_topic_failures([result]) == [
+        "GitHub metadata unavailable: HTTP 503"
+    ]
+
+
+def test_probes_are_derived_from_shared_catalog() -> None:
+    assert check_listings_api.TEXT_PROBES == listing_catalog.HTTP_PROBES
+    assert check_listings.PROBES == listing_catalog.BROWSER_PROBES
+
+
+def test_only_filter_accepts_documented_partial_name() -> None:
+    probes = check_listings.filter_probes(check_listings.PROBES, ["LobeHub"])
+
+    assert [probe.name for probe in probes] == ["LobeHub Skills"]
+
+
+class _FakeResponse:
+    status: int = 200
+
+
+class _FakePage:
+    def goto(self, *_args: object, **_kwargs: object) -> _FakeResponse:
+        return _FakeResponse()
+
+    def wait_for_load_state(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def inner_text(self, *_args: object, **_kwargs: object) -> str:
+        return "claude-skill-b2-cloud-storage"
+
+    def screenshot(self, *, path: str, full_page: bool) -> None:
+        assert full_page is True
+        Path(path).write_bytes(b"png")
+
+
+def test_screenshot_path_is_safe_for_probe_names_with_slashes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(check_listings, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(check_listings, "SCREENSHOT_DIR", tmp_path / "screens")
+    probe = listing_catalog.BrowserProbeSpec(
+        "owner/name",
+        "https://example.com",
+        match_terms=("claude-skill-b2-cloud-storage",),
+    )
+
+    result = check_listings.run_probe(_FakePage(), probe, save_screenshots=True)
+
+    assert result.screenshot is not None
+    assert result.screenshot == "screens/owner_name.png"
+    assert (tmp_path / result.screenshot).read_bytes() == b"png"

--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -9,14 +10,27 @@ WORKFLOW_DIR = Path(__file__).parent.parent / ".github" / "workflows"
 PINNED_ACTION = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@[a-f0-9]{40}$")
 
 
-def _workflow_steps() -> list[tuple[Path, dict[str, object]]]:
-    steps: list[tuple[Path, dict[str, object]]] = []
+def _workflow_docs() -> list[tuple[Path, dict[str, Any]]]:
+    docs: list[tuple[Path, dict[str, Any]]] = []
     for path in sorted(WORKFLOW_DIR.glob("*.yml")):
         data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        docs.append((path, data))
+    return docs
+
+
+def _workflow_steps() -> list[tuple[Path, dict[str, Any]]]:
+    steps: list[tuple[Path, dict[str, Any]]] = []
+    for path, data in _workflow_docs():
         for job in data.get("jobs", {}).values():
             for step in job.get("steps", []):
                 steps.append((path, step))
     return steps
+
+
+def _contents_permission(permissions: object) -> object:
+    if isinstance(permissions, dict):
+        return permissions.get("contents")
+    return permissions
 
 
 def test_workflow_actions_are_pinned_to_full_commit_shas() -> None:
@@ -40,5 +54,32 @@ def test_checkout_does_not_persist_credentials() -> None:
                 or with_config.get("persist-credentials") is not False
             ):
                 unsafe.append(path.name)
+
+    assert unsafe == []
+
+
+def test_non_release_workflows_are_explicitly_read_only() -> None:
+    unsafe = []
+    for path, data in _workflow_docs():
+        if path.name == "release.yml":
+            continue
+        if _contents_permission(data.get("permissions")) != "read":
+            unsafe.append(path.name)
+
+    assert unsafe == []
+
+
+def test_write_token_jobs_only_use_trusted_actions() -> None:
+    unsafe = []
+    for path, data in _workflow_docs():
+        workflow_permissions = data.get("permissions")
+        for job_name, job in data.get("jobs", {}).items():
+            permissions = job.get("permissions", workflow_permissions)
+            if _contents_permission(permissions) != "write":
+                continue
+            for step in job.get("steps", []):
+                uses = step.get("uses")
+                if isinstance(uses, str) and not uses.startswith("actions/"):
+                    unsafe.append(f"{path.name}:{job_name}:{uses}")
 
     assert unsafe == []

--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -14,6 +14,7 @@ def _workflow_docs() -> list[tuple[Path, dict[str, Any]]]:
     docs: list[tuple[Path, dict[str, Any]]] = []
     for path in sorted(WORKFLOW_DIR.glob("*.yml")):
         data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert isinstance(data, dict), f"{path.name} must contain a mapping document"
         docs.append((path, data))
     return docs
 

--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -7,7 +7,7 @@ from typing import Any
 import yaml
 
 WORKFLOW_DIR = Path(__file__).parent.parent / ".github" / "workflows"
-PINNED_ACTION = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@[a-f0-9]{40}$")
+PINNED_ACTION = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*@[a-f0-9]{40}$")
 
 
 def _workflow_docs() -> list[tuple[Path, dict[str, Any]]]:
@@ -42,6 +42,10 @@ def test_workflow_actions_are_pinned_to_full_commit_shas() -> None:
             unpinned.append(f"{path.name}: {uses}")
 
     assert unpinned == []
+
+
+def test_pinned_action_allows_subdirectory_actions() -> None:
+    assert PINNED_ACTION.match(f"github/codeql-action/init@{'a' * 40}") is not None
 
 
 def test_checkout_does_not_persist_credentials() -> None:

--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_DIR = Path(__file__).parent.parent / ".github" / "workflows"
+PINNED_ACTION = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@[a-f0-9]{40}$")
+
+
+def _workflow_steps() -> list[tuple[Path, dict[str, object]]]:
+    steps: list[tuple[Path, dict[str, object]]] = []
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job in data.get("jobs", {}).values():
+            for step in job.get("steps", []):
+                steps.append((path, step))
+    return steps
+
+
+def test_workflow_actions_are_pinned_to_full_commit_shas() -> None:
+    unpinned = []
+    for path, step in _workflow_steps():
+        uses = step.get("uses")
+        if isinstance(uses, str) and not PINNED_ACTION.match(uses):
+            unpinned.append(f"{path.name}: {uses}")
+
+    assert unpinned == []
+
+
+def test_checkout_does_not_persist_credentials() -> None:
+    unsafe = []
+    for path, step in _workflow_steps():
+        uses = step.get("uses")
+        if isinstance(uses, str) and uses.startswith("actions/checkout@"):
+            with_config = step.get("with") or {}
+            if (
+                not isinstance(with_config, dict)
+                or with_config.get("persist-credentials") is not False
+            ):
+                unsafe.append(path.name)
+
+    assert unsafe == []


### PR DESCRIPTION
## Why

Issue #1 tracks whether the skill is listed across roughly 30 marketplaces, and the repo already had two probe scripts for it (`check_listings_api.py`, `check_listings.py`). They were untracked and ran nowhere, so the tracker only ever got refreshed by hand. This wires listing monitoring into CI so listing drift and an accidentally dropped GitHub discovery topic get caught automatically.

## What changed

- Tracked the two listing-check scripts:
  - `scripts/check_listings_api.py`: pure-stdlib HTTP probe, safe for CI.
  - `scripts/check_listings.py`: Playwright probe for SPA sites, for local/manual use.
- Added `.github/workflows/listings.yml`:
  - Runs weekly (Mondays 09:00 UTC), on demand (`workflow_dispatch`), and when the HTTP probe, shared catalog, or workflow changes.
  - Runs the HTTP probe, writes the status report to the job summary, and uploads markdown/JSON artifacts.
  - Uses script-owned strict topic checks so GitHub metadata failures and missing discovery topics fail clearly, while third-party marketplace probe errors remain report-only.
  - Bounds the scheduled job runtime with `timeout-minutes`.
- Added `scripts/listing_catalog.py` as the shared marketplace catalog used by both HTTP and Playwright probes.
- Hardened HTTP probing with bounded response reads, total read deadlines for success and HTTP error bodies, and bounded GitHub metadata retries.
- Hardened workflows:
  - Pinned workflow actions to full commit SHAs and allowed pinned subdirectory actions in the security test.
  - Disabled checkout credential persistence where no git push is needed.
  - Set CI and lint workflow token permissions to `contents: read`.
  - Replaced the third-party release action in the write-token release job with GitHub CLI publishing from reviewed workflow code.
  - Added workflow security tests for pinned actions, checkout credentials, read-only non-release permissions, and privileged action allowlists.
- Fixed manual probe edges:
  - `--only LobeHub` now matches the documented `LobeHub Skills` probe.
  - Screenshot filenames are sanitized so probe names with `/` are written correctly.
- Cleaned listing script docs, including exit-code wording and a neutral `GITHUB_TOKEN=your-token` placeholder.

## Verified

- `ruff check .`
- `ruff format --check` on touched Python files
- `pytest tests/ -v`
- `mypy b2-cloud-storage/scripts tests`
- `python tests/validate_frontmatter.py b2-cloud-storage/SKILL.md`
- `python scripts/check_listings_api.py --strict --report dist/listings-api.md --json > dist/listings-api.json`
- PR checks pass on GitHub for pre-commit and Python 3.10 through 3.14.
