### PR TITLE
feat: add plugin.json manifest for community marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to full commit SHAs, checkout credentials are not persisted when unused, non-release
   workflows declare read-only token permissions, and release publishing uses the GitHub CLI
   instead of a third-party action in the write-token job.
+- `skills/b2-cloud-storage/.claude-plugin/plugin.json` plugin manifest, so the skill can be
+  submitted to the Anthropic community plugin marketplace and pass `claude plugin validate`.
+  Its `version` is kept in sync by `release.py` and enforced by `check_version.py`.
 
 ### Changed
 

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -11,6 +11,7 @@ Checked fields:
     - .claude-plugin/marketplace.json    metadata.version
     - .claude-plugin/marketplace.json    plugins[].version  (every entry)
     - skills/b2-cloud-storage/SKILL.md   frontmatter metadata.version
+    - skills/b2-cloud-storage/.claude-plugin/plugin.json  version
 
 Used by .github/workflows/release.yml as the gate before building artifacts,
 and by humans before running `git tag` if they want belt-and-suspenders.
@@ -26,6 +27,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 MARKETPLACE = REPO / ".claude-plugin" / "marketplace.json"
 SKILL_MD = REPO / "skills" / "b2-cloud-storage" / "SKILL.md"
+PLUGIN_JSON = REPO / "skills" / "b2-cloud-storage" / ".claude-plugin" / "plugin.json"
 
 SKILL_VERSION_RE = re.compile(r'^\s*version:\s*"([^"]+)"', re.MULTILINE)
 
@@ -50,6 +52,9 @@ def collect_versions() -> dict[str, str]:
     text = SKILL_MD.read_text()
     m = SKILL_VERSION_RE.search(text)
     versions["SKILL.md metadata.version"] = m.group(1) if m else "<not found>"
+
+    plugin = json.loads(PLUGIN_JSON.read_text())
+    versions["plugin.json version"] = str(plugin.get("version", "<missing>"))
 
     return versions
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -18,6 +18,7 @@ Optional flags:
 Updates version in:
   - skills/b2-cloud-storage/SKILL.md  (frontmatter `metadata.version`)
   - .claude-plugin/marketplace.json  (`metadata.version` and every `plugins[].version`)
+  - skills/b2-cloud-storage/.claude-plugin/plugin.json  (`version`)
 
 Rotates CHANGELOG.md:
   - Moves the body of `## [Unreleased]` into a new `## [X.Y.Z] - YYYY-MM-DD` section.
@@ -42,6 +43,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 SKILL_MD = REPO / "skills" / "b2-cloud-storage" / "SKILL.md"
 MARKETPLACE = REPO / ".claude-plugin" / "marketplace.json"
+PLUGIN_JSON = REPO / "skills" / "b2-cloud-storage" / ".claude-plugin" / "plugin.json"
 CHANGELOG = REPO / "CHANGELOG.md"
 
 SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
@@ -94,6 +96,12 @@ def update_marketplace_json(new_version: str) -> None:
     for plugin in data.get("plugins", []):
         plugin["version"] = new_version
     MARKETPLACE.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def update_plugin_json(new_version: str) -> None:
+    data = json.loads(PLUGIN_JSON.read_text())
+    data["version"] = new_version
+    PLUGIN_JSON.write_text(json.dumps(data, indent=2) + "\n")
 
 
 def rotate_changelog(new_version: str, previous_version: str) -> bool:
@@ -199,10 +207,12 @@ def main() -> None:
 
     update_skill_md(new_version)
     update_marketplace_json(new_version)
+    update_plugin_json(new_version)
     print(f"  Updated  {SKILL_MD.relative_to(REPO)}")
     print(f"  Updated  {MARKETPLACE.relative_to(REPO)}")
+    print(f"  Updated  {PLUGIN_JSON.relative_to(REPO)}")
 
-    files_to_stage: list[Path] = [SKILL_MD, MARKETPLACE]
+    files_to_stage: list[Path] = [SKILL_MD, MARKETPLACE, PLUGIN_JSON]
     if not args.no_changelog and rotate_changelog(new_version, current):
         files_to_stage.append(CHANGELOG)
 

--- a/skills/b2-cloud-storage/.claude-plugin/plugin.json
+++ b/skills/b2-cloud-storage/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "b2-cloud-storage",
+  "version": "1.2.0",
+  "description": "Manage Backblaze B2 cloud storage from the terminal: list, audit, cleanup, security review, and lifecycle.",
+  "author": {
+    "name": "Backblaze Labs",
+    "url": "https://github.com/backblaze-labs"
+  },
+  "homepage": "https://github.com/backblaze-labs/claude-skill-b2-cloud-storage",
+  "repository": "https://github.com/backblaze-labs/claude-skill-b2-cloud-storage",
+  "license": "MIT",
+  "keywords": [
+    "backblaze",
+    "b2",
+    "cloud-storage",
+    "object-storage",
+    "claude-skills"
+  ]
+}


### PR DESCRIPTION
## Why

Unblocks submitting the skill to Anthropic's community plugin marketplace (`anthropics/claude-plugins-community`), the only self-serve official-adjacent listing path. Its review pipeline runs `claude plugin validate`, which expects a `.claude-plugin/plugin.json` on the plugin. We only had `marketplace.json` before.

## What changed

- Added `skills/b2-cloud-storage/.claude-plugin/plugin.json`. The plugin root already holds a single `SKILL.md`, which Claude Code loads as one skill (confirmed against the plugins reference), so no restructure was needed. `name` is the only required field; included version, author, homepage, repository, license, keywords.
- Kept `version` from drifting: wired `plugin.json` into `check_version.py` (release gate now verifies 4 fields) and `release.py` (bumps it alongside SKILL.md + marketplace.json).

## Verified locally

- `plugin.json` valid JSON, `name` = `b2-cloud-storage`.
- `check_version.py 1.2.0`: all 4 version fields match.
- `release.py --dry-run patch`: bumps cleanly.
- Full pre-commit suite passes on the changed files.