### PR TITLE
docs: close Anthropic Software Directory policy gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `skills/b2-cloud-storage/.claude-plugin/plugin.json` plugin manifest, so the skill can be
   submitted to the Anthropic community plugin marketplace and pass `claude plugin validate`.
   Its `version` is kept in sync by `release.py` and enforced by `check_version.py`.
+- `SECURITY.md` vulnerability-disclosure policy (private GitHub advisories for skill-code
+  issues; Backblaze Trust Center for B2-platform issues), satisfying the Anthropic Software
+  Directory contact/security-channel requirement.
+- Top-level **Privacy** section in the README stating the skill collects no data and
+  transmits nothing to the authors, with a link to Backblaze's privacy policy.
 
 ### Changed
 
@@ -29,13 +34,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed ZIP release artifact paths so they keep the public `b2-cloud-storage/` archive root.
 - Removed agent-managed B2 CLI package installation guidance; users install the CLI themselves.
 
+### Fixed
+
+- License badge in the README now links to the actual `LICENSE` file (was a dead
+  `LICENSE.txt` link).
+
 ## [1.2.0] - 2026-04-28
 
 ### Added
 
 - `.claude-plugin/marketplace.json` — Claude Code plugin marketplace manifest, enabling auto-discovery on
   [claudemarketplaces.com](https://claudemarketplaces.com) and one-command install via `/plugin marketplace add`.
-- `LICENSE.txt` — explicit MIT license file (was previously declared in frontmatter only).
+- `LICENSE` — explicit MIT license file (was previously declared in frontmatter only).
 - `RELEASE.md` — release runbook documenting the single-command flow.
 - `CHANGELOG.md` (this file).
 - Release tooling under `scripts/`:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Claude Skill: Backblaze B2 Cloud Storage Manager
 
 [![CI](https://github.com/backblaze-labs/claude-skill-b2-cloud-storage/actions/workflows/ci.yml/badge.svg)](https://github.com/backblaze-labs/claude-skill-b2-cloud-storage/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.txt)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python 3.10–3.14](https://img.shields.io/badge/python-3.10%E2%80%933.14-3776AB?logo=python&logoColor=white)](https://www.python.org/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
@@ -212,6 +212,19 @@ An example config file is included at [`skills/b2-cloud-storage/b2-config.exampl
 - All operations default to read-only
 - API keys are never stored or displayed by the skill
 - If you accidentally paste keys into chat, the skill warns you to rotate them
+
+To report a security vulnerability, see [`SECURITY.md`](SECURITY.md).
+
+## Privacy
+
+This skill collects no data. It ships no telemetry and sends nothing to the skill's
+authors or any third party. Every operation runs locally: the skill invokes the
+user-installed `b2` CLI, which talks only to Backblaze B2 using **your own** credentials.
+Those credentials are stored by the `b2` CLI in `~/.b2_account_info` and are never read,
+stored, or transmitted by the skill (see [Security](#security)).
+
+Data you store in or retrieve from Backblaze B2 is governed by Backblaze's
+[Privacy Policy](https://www.backblaze.com/company/policy/privacy).
 
 ## File Structure
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release is supported. Please upgrade before reporting an issue.
+
+## Reporting a vulnerability
+
+**A vulnerability in this skill's code** — the `b2` command guidance in `SKILL.md`, the
+audit script, CI workflows, or docs:
+
+- Report it privately through GitHub. Open the repository's **Security** tab and click
+  **"Report a vulnerability"** to file a private advisory.
+- Please do **not** open a public issue for a security problem.
+
+**A vulnerability in the Backblaze B2 platform itself** — the service, the S3/B2 API, or
+the `b2` CLI binary:
+
+- Report it through Backblaze's official channel at the
+  [Backblaze Trust Center](https://www.backblaze.com/company/trust-center). It does not
+  belong in this repository.
+
+We triage reports on a best-effort basis, acknowledge them, and work with you on a fix.
+This is a community project with no formal response-time SLA.
+
+## Scope note
+
+This file covers **vulnerability disclosure**. For hardening *your own* B2 buckets
+(bucket type, encryption, CORS, object lock, lifecycle), see the operational checklist in
+[`skills/b2-cloud-storage/references/security-review.md`](skills/b2-cloud-storage/references/security-review.md).


### PR DESCRIPTION
## What & why

Closes the repo-fixable gaps found when reviewing this skill against the
[Anthropic Software Directory Policy](https://support.claude.com/en/articles/13145358-anthropic-software-directory-policy).
Docs-only — no change to skill behavior, the audit script, or CI logic.

## Changes

| File | Change | Policy gap |
|---|---|---|
| `SECURITY.md` (new) | Vulnerability-disclosure policy: private GitHub advisories for skill-code issues, Backblaze Trust Center for B2-platform issues, best-effort (no false SLA), scope note cross-linking `references/security-review.md`. Resolves the 3 dead `SECURITY.md` links in `CONTRIBUTING.md`. | **3B** security/contact channel |
| `README.md` | New top-level `## Privacy` section (no data collection, no telemetry, all traffic under the user's own credentials, link to Backblaze's privacy policy) + a `SECURITY.md` pointer. Fixed the license badge (`LICENSE.txt` → `LICENSE`). | **3A** privacy link; broken link |
| `CHANGELOG.md` | `[Unreleased]` Added/Fixed entries; corrected historical `LICENSE.txt` filename. | — |

## Notes / decisions

- **No published security email** — GitHub private advisories (already enabled on this repo) + Backblaze Trust Center instead of an unverifiable inbox.
- **`SKILL.md` untouched** — privacy disclosure is human-facing; keeping it out of the model prompt avoids dead tokens.
- **UTM marketing links left as-is** — Section 4C passes; `SKILL.md` is clean and the UTM params are README-only first-party analytics. Easy to strip later if preferred.

## Still submission-form steps (not repo artifacts)

- **3D** testing account with sample data for reviewers
- **3F** confirm `backblaze-labs` org control
- **3H** agree to the Software Directory Terms

## Verification

- `pytest tests/` → 30 passed
- `cspell` → 0 issues; `markdownlint-cli2@v0.14.0` (pinned CI version) → 0 errors on changed files
