### PR TITLE
docs: align branding with Anthropic trademark guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Directory contact/security-channel requirement.
 - Top-level **Privacy** section in the README stating the skill collects no data and
   transmits nothing to the authors, with a link to Backblaze's privacy policy.
+- **Trademarks** section in the README disclaiming Anthropic affiliation/endorsement and
+  attributing the Claude, Claude Code, and Backblaze marks to their owners, aligning with
+  Anthropic's trademark guidelines.
 
 ### Changed
 
+- Trademark-compliance edits to the README: retitled the heading to "Backblaze B2 Cloud
+  Storage — a skill for Claude Code" (was "Claude Skill: …", which read as a product name),
+  and removed the Anthropic logo from the Claude Code badge (an unauthorized, recolored
+  rendering of the mark).
 - Moved the skill from `b2-cloud-storage/` to `skills/b2-cloud-storage/` so marketplace
   crawlers that scan the conventional `skills/<name>/SKILL.md` path can discover it. Release
   artifacts still root at `b2-cloud-storage/`, so install commands and URLs are unchanged.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Claude Skill: Backblaze B2 Cloud Storage Manager
+# Backblaze B2 Cloud Storage — a skill for Claude Code
 
 [![CI](https://github.com/backblaze-labs/claude-skill-b2-cloud-storage/actions/workflows/ci.yml/badge.svg)](https://github.com/backblaze-labs/claude-skill-b2-cloud-storage/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -7,7 +7,7 @@
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Spell-checked: cspell](https://img.shields.io/badge/spell--check-cspell-blue)](https://cspell.org/)
-[![Claude Code](https://img.shields.io/badge/Claude%20Code-compatible-8B5CF6?logo=anthropic&logoColor=white)](https://claude.ai/code)
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-compatible-8B5CF6)](https://claude.ai/code)
 [![Agent Skills](https://img.shields.io/badge/Agent%20Skills-spec-FF6B35)](https://agentskills.io)
 [![Backblaze B2](https://img.shields.io/badge/Backblaze-B2-E8231A?logo=backblaze&logoColor=white)](https://www.backblaze.com/cloud-storage)
 [![GitHub stars](https://img.shields.io/github/stars/backblaze-labs/claude-skill-b2-cloud-storage?style=flat&logo=github)](https://github.com/backblaze-labs/claude-skill-b2-cloud-storage/stargazers)
@@ -256,3 +256,10 @@ claude-skill-b2-cloud-storage/
 ## License
 
 MIT
+
+## Trademarks
+
+This skill is an independent, community-maintained project. It is not affiliated
+with, sponsored, or endorsed by Anthropic. Claude and Claude Code are trademarks
+of Anthropic. Backblaze and Backblaze B2 are trademarks of Backblaze.
+References to these products are for identification and compatibility purposes only.


### PR DESCRIPTION
## Summary

Docs-only changes to bring the repo in line with [Anthropic's trademark guidelines](https://www.anthropic.com/legal/trademark-guidelines). No change to skill behavior, `SKILL.md`, or scripts.

Three fixes:

1. **Removed the Anthropic logo from the Claude Code badge** — the badge used `?logo=anthropic&logoColor=white`, a recolored, third-party-sourced rendering of the mark (guidelines prohibit altering marks and require Anthropic-supplied images). Badge still reads "Claude Code · compatible".
2. **Retitled the README heading** from `Claude Skill: Backblaze B2 Cloud Storage Manager` → `Backblaze B2 Cloud Storage — a skill for Claude Code`, so "Claude" is used referentially rather than as the product name (avoids implying an Anthropic product/affiliation).
3. **Added a Trademarks section** disclaiming affiliation/endorsement and attributing the Claude, Claude Code, and Backblaze marks to their owners.

## Intentionally left as-is

- **Repo slug** `claude-skill-b2-cloud-storage` — descriptive, low-risk, expensive to rename.
- **"Compatible with Claude Code" phrasing** — truthful nominative use.
- **Badge color `#8B5CF6`** — not an Anthropic brand color.

## Note on scope

This PR also carries the earlier `docs: close anthropic software directory policy gaps` commit (`317cf75`), which was not yet on `main`. Both commits are Anthropic-compliance docs.

## Verify

- CI (markdownlint + cspell) runs on this PR. Disclaimer avoids out-of-dictionary acronyms (no `PBC`/`Inc`) to keep cspell green.
- Confirm the badge and heading render correctly in the GitHub README preview.