### PR TITLE
docs(security): expand disclosure policy and add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Keeps third-party GitHub Actions current. The workflows SHA-pin every action, which
+# freezes them; Dependabot proposes weekly PRs that bump those pins to the latest release
+# with the version noted in a trailing comment. This is the intended complement to pinning
+# and satisfies the OpenSSF Scorecard dependency-update-tool check.
+#
+# Only the github-actions ecosystem is tracked. The Python dev tooling (ruff, pytest,
+# pyyaml) is installed unpinned in CI with no manifest for Dependabot to read; pre-commit
+# hooks are updated via `pre-commit autoupdate` (see CONTRIBUTING.md).
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `skills/b2-cloud-storage/.claude-plugin/plugin.json` plugin manifest, so the skill can be
   submitted to the Anthropic community plugin marketplace and pass `claude plugin validate`.
   Its `version` is kept in sync by `release.py` and enforced by `check_version.py`.
-- `SECURITY.md` vulnerability-disclosure policy (private GitHub advisories for skill-code
-  issues; Backblaze Trust Center for B2-platform issues), satisfying the Anthropic Software
-  Directory contact/security-channel requirement.
+- `SECURITY.md` vulnerability-disclosure policy: in/out-of-scope reporting (private GitHub
+  advisories for skill-code issues; Backblaze Trust Center for B2-platform issues; Anthropic
+  for Claude Code / API issues), best-effort response targets, and a data-handling section
+  (no telemetry, credentials never logged, dry-run-gated deletions, no hooks) that links to
+  the README Privacy/Security and contributor security rules. Satisfies the Anthropic
+  Software Directory contact/security-channel requirement.
+- `.github/dependabot.yml` — weekly `github-actions` version updates that bump the
+  SHA-pinned action references, complementing the existing pinning and secret-scanning /
+  Dependabot-alerts settings already enabled on the repository.
 - Top-level **Privacy** section in the README stating the skill collects no data and
   transmits nothing to the authors, with a link to Backblaze's privacy policy.
 - **Trademarks** section in the README disclaiming Anthropic affiliation/endorsement and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,25 +6,42 @@ Only the latest release is supported. Please upgrade before reporting an issue.
 
 ## Reporting a vulnerability
 
-**A vulnerability in this skill's code** — the `b2` command guidance in `SKILL.md`, the
-audit script, CI workflows, or docs:
+In scope: this repository's code — the `b2` command guidance in `SKILL.md`, the audit and
+helper scripts under `scripts/`, the CI workflows, and the docs.
 
 - Report it privately through GitHub. Open the repository's **Security** tab and click
   **"Report a vulnerability"** to file a private advisory.
 - Please do **not** open a public issue for a security problem.
 
-**A vulnerability in the Backblaze B2 platform itself** — the service, the S3/B2 API, or
-the `b2` CLI binary:
+Out of scope — please report these to the party that owns them, not here:
 
-- Report it through Backblaze's official channel at the
-  [Backblaze Trust Center](https://www.backblaze.com/company/trust-center). It does not
-  belong in this repository.
+- **The Backblaze B2 platform** (the service, the S3/B2 API, or the `b2` CLI binary) —
+  report through the
+  [Backblaze Trust Center](https://www.backblaze.com/company/trust-center).
+- **Claude Code or the Anthropic API** — report to Anthropic through their
+  [responsible disclosure program](https://www.anthropic.com/responsible-disclosure-policy).
 
-We triage reports on a best-effort basis, acknowledge them, and work with you on a fix.
-This is a community project with no formal response-time SLA.
+This channel is open to anyone — Anthropic and third-party reporters alike. We investigate
+reports with reasonable care: we aim to acknowledge within about 14 days and to coordinate
+public disclosure within about 90 days or when a fix ships, whichever comes first. These
+are best-effort targets for a community project, not a formal SLA.
 
-## Scope note
+## What this skill does with your data
 
-This file covers **vulnerability disclosure**. For hardening *your own* B2 buckets
+These properties are what a reviewer or user should be able to rely on; a change to any of
+them is a security-relevant change:
+
+- It collects no data and ships no telemetry — see [Privacy](README.md#privacy).
+- The skill makes no network calls of its own. It invokes the user-installed `b2` CLI,
+  which talks only to Backblaze B2 with your credentials; those credentials are never read,
+  logged, or transmitted by the skill — see [Security](README.md#security).
+- Destructive operations are gated behind a `--dry-run` preview and an explicit "yes"
+  confirmation, and operations default to read-only — see the
+  [contributor security rules](CONTRIBUTING.md#security).
+- The skill defines no hooks and installs no additional software.
+
+## Hardening your own buckets
+
+The sections above cover **vulnerability disclosure**. For hardening *your own* B2 buckets
 (bucket type, encryption, CORS, object lock, lifecycle), see the operational checklist in
 [`skills/b2-cloud-storage/references/security-review.md`](skills/b2-cloud-storage/references/security-review.md).

--- a/cspell.json
+++ b/cspell.json
@@ -39,6 +39,7 @@
     "contentsha",
     "cspell",
     "deduplication",
+    "Dependabot",
     "dryrun",
     "fileid",
     "frontmatter",


### PR DESCRIPTION
## What

Expands `SECURITY.md` from a minimal disclosure note into a lean, complete policy, and adds a Dependabot config for GitHub Actions.

### `SECURITY.md`
- **In/out-of-scope reporting** — folds scope into the report bullets; routes B2-platform bugs to the Backblaze Trust Center and Claude Code / Anthropic API bugs to Anthropic.
- **Software Directory terms alignment** — the report channel is stated as open to Anthropic and third-party reporters, investigated *with reasonable care*, mirroring the marketplace terms' vulnerability-report obligation.
- **Response expectations** — best-effort ~14-day acknowledgment and ~90-day coordinated disclosure (or on fix), explicitly not a formal SLA. The soft numeric targets also satisfy the OpenSSF Scorecard security-policy timeframe check.
- **Data-handling section** — behavior-only assertions (no telemetry, credentials never logged, dry-run-gated deletions, no hooks, no extra software installs) that **link** to the existing README Privacy/Security and contributor security rules rather than duplicating them.
- Renamed the colliding `## Scope note` → `## Hardening your own buckets`.

### `.github/dependabot.yml`
- Weekly `github-actions` version updates to bump the SHA-pinned action references, complementing the existing pinning and satisfying the Scorecard dependency-update-tool check.
- pip is intentionally excluded (no manifest; dev-only unpinned deps); pre-commit hooks stay on `pre-commit autoupdate`.

### Supporting
- `CHANGELOG.md` — amended the existing unreleased `SECURITY.md` entry in place and noted the Dependabot config.
- `cspell.json` — added `Dependabot` to the dictionary.

## Why

Aligns the security posture with the Anthropic Software Directory Policy/terms (a maintained mechanism to receive vulnerability reports from Anthropic and third parties, investigated with reasonable care) and with GitHub/OpenSSF disclosure best practice, without over-engineering a docs+scripts skill.

## Deliberately omitted (overkill for this repo)

A hand-maintained CVE/dependency log (anti-pattern — drifts, implies an unkept commitment), PGP keys, `security.txt` (no served website), safe-harbor legal boilerplate (no deployed system to probe), and CodeQL. Private Vulnerability Reporting, secret scanning + push protection, and Dependabot alerts are already enabled on the repo.

## Verification

- `pytest tests/`: 30/30 pass
- markdownlint: 0 errors · cspell: clean · yamllint: clean · YAML/JSON valid
