### PR TITLE
fix: resolve CodeQL and Copilot code-quality findings

### DIFF
--- a/scripts/check_listings.py
+++ b/scripts/check_listings.py
@@ -89,13 +89,11 @@ def _check_page_text(text: str, probe: BrowserProbeSpec) -> tuple[Status, str | 
 
 def _dismiss_overlays(page: Page) -> None:
     """Best-effort: close common modals/banners that block search input."""
-    # Two Escape presses — some modals require it; one to defocus, one to close.
+    # Two Escape presses (defocus, then close); best-effort, so ignore input errors.
     for _ in range(2):
-        try:
+        with contextlib.suppress(Exception):
             page.keyboard.press("Escape", timeout=500)
             page.wait_for_timeout(150)
-        except Exception:
-            pass
     candidates = (
         'button[aria-label="Dismiss"]',
         'button[aria-label="Close"]',
@@ -216,11 +214,10 @@ def run_probe(page: Page, probe: BrowserProbeSpec, save_screenshots: bool) -> Re
         if save_screenshots and probe.url.startswith("http") and result.status != "error":
             SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
             path = screenshot_path_for_probe(probe.name)
-            try:
+            # Screenshots are evidence, not required output; never fail the probe over one.
+            with contextlib.suppress(Exception):
                 page.screenshot(path=str(path), full_page=True)
                 result.screenshot = str(path.relative_to(REPO_ROOT))
-            except Exception:
-                pass
         result.duration_ms = int((datetime.now(timezone.utc) - started).total_seconds() * 1000)
     return result
 

--- a/scripts/listing_catalog.py
+++ b/scripts/listing_catalog.py
@@ -4,6 +4,18 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+# Public surface consumed by the sibling checkers (check_listings*.py) and tests.
+# HTTP_PROBES / BROWSER_PROBES look unused within this module, but are imported
+# elsewhere; listing them here documents the export and satisfies that analysis.
+__all__ = [
+    "BROWSER_PROBES",
+    "HTTP_PROBES",
+    "REPO_SLUG",
+    "SKILL_NAME",
+    "BrowserProbeSpec",
+    "HttpProbeSpec",
+]
+
 REPO_SLUG = "backblaze-labs/claude-skill-b2-cloud-storage"
 SKILL_NAME = "b2-cloud-storage"
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -171,7 +171,9 @@ def run(cmd: list[str]) -> str:
 
 
 def ensure_clean_tree() -> None:
-    if run(["git", "status", "--porcelain"]):
+    # `run` already strips, so a non-empty result means there are pending changes.
+    status = run(["git", "status", "--porcelain"])
+    if status:
         raise SystemExit("Working tree is not clean. Commit or stash first.")
 
 
@@ -230,7 +232,7 @@ def main() -> None:
         return
 
     tag = f"v{new_version}"
-    run(["git", "add", *[str(p) for p in files_to_stage]])
+    run(["git", "add", *(str(p) for p in files_to_stage)])
     run(["git", "commit", "-m", f"chore: release {tag}"])
     print(f"  Committed: chore: release {tag}")
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shlex
 import subprocess
 import sys
 from datetime import date
@@ -165,7 +166,7 @@ def run(cmd: list[str]) -> str:
         # Surface git's own stderr (e.g. why a checkout/status failed) instead of a
         # bare CalledProcessError traceback.
         details = (exc.stderr or exc.stdout or "").strip()
-        message = f"Command failed (exit {exc.returncode}): {' '.join(cmd)}"
+        message = f"Command failed (exit {exc.returncode}): {shlex.join(cmd)}"
         if details:
             message = f"{message}\n{details}"
         print(message, file=sys.stderr)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -158,7 +158,16 @@ def _update_changelog_links(text: str, new_version: str, previous_version: str) 
 
 
 def run(cmd: list[str]) -> str:
-    return subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
+    try:
+        return subprocess.run(cmd, check=True, capture_output=True, text=True).stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        # Surface git's own stderr (e.g. why a checkout/status failed) instead of a
+        # bare CalledProcessError traceback.
+        details = (exc.stderr or exc.stdout or "").strip()
+        message = f"Command failed (exit {exc.returncode}): {' '.join(cmd)}"
+        if details:
+            message = f"{message}\n{details}"
+        raise SystemExit(message) from None
 
 
 def ensure_clean_tree() -> None:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -37,6 +37,7 @@ import argparse
 import json
 import re
 import subprocess
+import sys
 from datetime import date
 from pathlib import Path
 
@@ -167,7 +168,8 @@ def run(cmd: list[str]) -> str:
         message = f"Command failed (exit {exc.returncode}): {' '.join(cmd)}"
         if details:
             message = f"{message}\n{details}"
-        raise SystemExit(message) from None
+        print(message, file=sys.stderr)
+        raise SystemExit(exc.returncode) from None
 
 
 def ensure_clean_tree() -> None:

--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -8,7 +8,10 @@ import yaml
 
 WORKFLOW_DIR = Path(__file__).parent.parent / ".github" / "workflows"
 # Fully pinned `uses`: owner/repo@<40-char sha> or owner/repo/sub/path@<40-char sha>.
-PINNED_ACTION = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*@[a-f0-9]{40}$")
+PINNED_ACTION = re.compile(
+    r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*@[a-f0-9]{40}$",
+    re.IGNORECASE,
+)
 
 
 def _workflow_docs() -> list[tuple[Path, dict[str, Any]]]:
@@ -50,6 +53,10 @@ def test_workflow_actions_are_pinned_to_full_commit_shas() -> None:
 
 def test_pinned_action_allows_subdirectory_actions() -> None:
     assert PINNED_ACTION.match(f"github/codeql-action/init@{'a' * 40}") is not None
+
+
+def test_pinned_action_allows_uppercase_shas() -> None:
+    assert PINNED_ACTION.match(f"actions/checkout@{'A' * 40}") is not None
 
 
 def test_checkout_does_not_persist_credentials() -> None:

--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -58,6 +58,7 @@ def test_checkout_does_not_persist_credentials() -> None:
         uses = step.get("uses")
         if isinstance(uses, str) and uses.startswith("actions/checkout@"):
             with_config = step.get("with") or {}
+            # Must be explicitly False; a missing/None persist-credentials is unsafe.
             if (
                 not isinstance(with_config, dict)
                 or with_config.get("persist-credentials") is not False

--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -7,6 +7,7 @@ from typing import Any
 import yaml
 
 WORKFLOW_DIR = Path(__file__).parent.parent / ".github" / "workflows"
+# Fully pinned `uses`: owner/repo@<40-char sha> or owner/repo/sub/path@<40-char sha>.
 PINNED_ACTION = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*@[a-f0-9]{40}$")
 
 
@@ -39,7 +40,10 @@ def test_workflow_actions_are_pinned_to_full_commit_shas() -> None:
     for path, step in _workflow_steps():
         uses = step.get("uses")
         if isinstance(uses, str) and not PINNED_ACTION.match(uses):
-            unpinned.append(f"{path.name}: {uses}")
+            unpinned.append(
+                f"{path.name}: {uses} "
+                "(pin to the full 40-character commit SHA, e.g. owner/repo@<sha>)"
+            )
 
     assert unpinned == []
 


### PR DESCRIPTION
Resolves the open GitHub "Code quality" findings on `main`: 4 CodeQL Standard findings and all 6 Copilot AI findings. Each fix is minimal and preserves existing behavior; the two "unused global" hits were false positives (the globals are imported by sibling scripts and asserted in tests), so they are handled via an explicit `__all__` export rather than deletion.

## CodeQL Standard findings

`py/empty-except` (x2) in `scripts/check_listings.py`: replaced both `try/except Exception: pass` blocks with `contextlib.suppress(Exception)` (the idiom already used elsewhere in the file, and what ruff `SIM105` prefers). With no `except` clause left, the rule no longer applies.

`py/unused-global-variable` (x2) in `scripts/listing_catalog.py`: `HTTP_PROBES` and `BROWSER_PROBES` are consumed by `check_listings_api.py`, `check_listings.py`, and the listing tests, but CodeQL only analyzes within a module. Added an explicit `__all__` export list, which is the documented suppression mechanism for this rule ("not explicitly made public by inclusion in the `__all__` list") and also documents the module's public API.

## Copilot AI findings

`scripts/release.py` (3): `run()` now catches `CalledProcessError`, prints the command failure details to stderr, and exits with the original subprocess return code instead of a bare traceback; `ensure_clean_tree()` uses a named `status` variable for an explicit non-empty check; the `git add` call drops the unnecessary intermediate list (`*(str(p) for p in files_to_stage)`).

`tests/test_workflow_security.py` (3): added a concise comment documenting the `PINNED_ACTION` regex format; the unpinned-action assertion message now tells you to pin to the full 40-character commit SHA with an example; added a one-line comment explaining why `persist-credentials is not False` uses an identity check (a missing/None value must count as unsafe).

## Review follow-ups

`scripts/release.py`: the failure handler now preserves the failed command's exit code with `SystemExit(exc.returncode)` and formats commands with `shlex.join(cmd)` so arguments containing spaces are quoted clearly in error output.

`tests/test_workflow_security.py`: the pinned-action regex now uses case-insensitive matching so uppercase commit SHAs are accepted, with a regression test covering that case.

## Verification

Original full local CI matrix was green: `pre-commit run --all-files` (ruff, ruff-format, markdownlint, yamllint, cspell, mypy), `ruff check skills/b2-cloud-storage/scripts tests`, `pytest tests/` (30 passed), and `validate_frontmatter.py`. The `run()` failure path and `ensure_clean_tree()` were also exercised directly.

Post-review targeted checks are green: `ruff check scripts/release.py tests/test_workflow_security.py`, `pytest tests/test_workflow_security.py` (6 passed), and a direct `run()` failure-path probe confirming exit code preservation and quoted arguments.

Note: the GitHub "Code quality" panels are computed against `main`, so they will only clear once this merges and CodeQL / Copilot re-scan the updated files.
