### PR TITLE
chore(deps): bump GitHub Actions (checkout, setup-python, setup-node, upload-artifact)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     name: test (Python ${{ matrix.python-version }})
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     name: pre-commit (ruff, markdownlint, yamllint, cspell, mypy)
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: "20"
 

--- a/.github/workflows/listings.yml
+++ b/.github/workflows/listings.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     name: marketplace listing check (HTTP)
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: listings-report
           if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
Consolidates the four open Dependabot GitHub Actions bumps into a single PR. Each action is pinned to a full 40-character commit SHA (the repo enforces SHA pinning via `tests/test_workflow_security.py`), and these SHAs are exactly the ones Dependabot resolved for each target version.

## Bumps

`actions/checkout` 4.3.1 → 7.0.0 (`34e1148` → `9c091bb`), used in ci.yml, lint.yml, listings.yml, release.yml.

`actions/setup-python` 5.6.0 → 6.3.0 (`a26af69` → `ece7cb0`), used in ci.yml, lint.yml, listings.yml, release.yml.

`actions/setup-node` 4.4.0 → 7.0.0 (`49933ea` → `8207627`), used in lint.yml.

`actions/upload-artifact` 4.6.2 → 7.0.1 (`ea165f8` → `043fb46`), used in listings.yml.

## Supersedes

Replaces and closes the individual Dependabot PRs #11, #12, #13, and #14.

## Verification

Full local CI matrix is green: `pre-commit run --all-files` (ruff, ruff-format, markdownlint, yamllint, cspell, mypy) and `pytest tests/` (31 passed), including the workflow-security tests that assert every `uses:` is pinned to a full 40-character SHA and that no non-release workflow gains write permissions.
