### PR TITLE
test: widen trusted-action allowlist for write-token jobs

### DIFF
--- a/tests/test_workflow_security.py
+++ b/tests/test_workflow_security.py
@@ -12,6 +12,8 @@ PINNED_ACTION = re.compile(
     r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*@[a-f0-9]{40}$",
     re.IGNORECASE,
 )
+# First-party namespaces trusted in write-token jobs (e.g. actions/*, github/codeql-action).
+TRUSTED_ACTION_PREFIXES = ("actions/", "github/")
 
 
 def _workflow_docs() -> list[tuple[Path, dict[str, Any]]]:
@@ -96,7 +98,7 @@ def test_write_token_jobs_only_use_trusted_actions() -> None:
                 continue
             for step in job.get("steps", []):
                 uses = step.get("uses")
-                if isinstance(uses, str) and not uses.startswith("actions/"):
+                if isinstance(uses, str) and not uses.startswith(TRUSTED_ACTION_PREFIXES):
                     unsafe.append(f"{path.name}:{job_name}:{uses}")
 
     assert unsafe == []


### PR DESCRIPTION
Addresses a Copilot code-quality finding on `test_write_token_jobs_only_use_trusted_actions`. That test allowed only the single `actions/` prefix in write-token jobs, which is too narrow: a write-permission job may legitimately use other GitHub first-party actions such as `github/codeql-action/...`, so the check could produce false positives.

## Change

Introduces a named `TRUSTED_ACTION_PREFIXES = ("actions/", "github/")` constant and passes it to `str.startswith` (which accepts a tuple), replacing the hard-coded `uses.startswith("actions/")`. The trust list is now explicit, self-documenting, and easy to extend.

## Verification

Full local CI matrix is green: `pre-commit run --all-files` (ruff, ruff-format, markdownlint, yamllint, cspell, mypy) and `pytest tests/` (31 passed), including `test_write_token_jobs_only_use_trusted_actions` itself. Scoped to the one test file (+3/-1); independent of the dependency-bump PR #16.
